### PR TITLE
Switch to UB-free `const-type-layout`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustacuda_core = "0.1.2"
 rustacuda = { version = "0.1.3", optional = true }
 rustacuda_derive = { version = "0.1.2", optional = true }
 
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "ae040f1" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "aa5ad03" }
 
 final = "0.1.1"
 hashbrown = { version = "0.12", default-features = false, features = ["inline-more"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustacuda_core = "0.1.2"
 rustacuda = { version = "0.1.3", optional = true }
 rustacuda_derive = { version = "0.1.2", optional = true }
 
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "7be4521" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "93d3661" }
 
 final = "0.1.1"
 hashbrown = { version = "0.12", default-features = false, features = ["inline-more"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustacuda_core = "0.1.2"
 rustacuda = { version = "0.1.3", optional = true }
 rustacuda_derive = { version = "0.1.2", optional = true }
 
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "93d3661" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "ae040f1" }
 
 final = "0.1.1"
 hashbrown = { version = "0.12", default-features = false, features = ["inline-more"], optional = true }

--- a/examples/derive/Cargo.toml
+++ b/examples/derive/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "ae040f1" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "aa5ad03" }
 rust-cuda = { path = "../../", features = ["derive", "host"] }

--- a/examples/derive/Cargo.toml
+++ b/examples/derive/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "7be4521" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "93d3661" }
 rust-cuda = { path = "../../", features = ["derive", "host"] }

--- a/examples/derive/Cargo.toml
+++ b/examples/derive/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "93d3661" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "ae040f1" }
 rust-cuda = { path = "../../", features = ["derive", "host"] }

--- a/examples/derive/src/lib.rs
+++ b/examples/derive/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(const_mut_refs)]
 
 #[derive(rust_cuda::common::LendRustToCuda)]
+#[r2cLayout(free = "T")]
 struct Inner<T>
 where
     T: Copy + rust_cuda::common::RustToCuda,
@@ -16,6 +17,7 @@ where
 }
 
 #[derive(rust_cuda::common::LendRustToCuda)]
+#[r2cLayout(free = "T")]
 struct Outer<T>
 where
     T: Copy + rust_cuda::common::RustToCuda,

--- a/examples/derive/src/lib.rs
+++ b/examples/derive/src/lib.rs
@@ -7,21 +7,21 @@
 #![feature(const_mut_refs)]
 
 #[derive(rust_cuda::common::LendRustToCuda)]
-#[r2cLayout(free = "T")]
+#[cuda(layout::free = "T")]
 struct Inner<T>
 where
     T: Copy + rust_cuda::common::RustToCuda,
 {
-    #[r2cEmbed]
+    #[cuda(embed)]
     inner: T,
 }
 
 #[derive(rust_cuda::common::LendRustToCuda)]
-#[r2cLayout(free = "T")]
+#[cuda(layout::free = "T")]
 struct Outer<T>
 where
     T: Copy + rust_cuda::common::RustToCuda,
 {
-    #[r2cEmbed]
+    #[cuda(embed)]
     inner: Inner<T>,
 }

--- a/examples/derive/src/lib.rs
+++ b/examples/derive/src/lib.rs
@@ -7,21 +7,13 @@
 #![feature(const_mut_refs)]
 
 #[derive(rust_cuda::common::LendRustToCuda)]
-#[cuda(layout::free = "T")]
-struct Inner<T>
-where
-    T: Copy + rust_cuda::common::RustToCuda,
-{
+struct Inner<T: Copy> {
     #[cuda(embed)]
     inner: T,
 }
 
 #[derive(rust_cuda::common::LendRustToCuda)]
-#[cuda(layout::free = "T")]
-struct Outer<T>
-where
-    T: Copy + rust_cuda::common::RustToCuda,
-{
+struct Outer<T: Copy> {
     #[cuda(embed)]
     inner: Inner<T>,
 }

--- a/examples/single-source/Cargo.toml
+++ b/examples/single-source/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "93d3661" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "ae040f1" }
 
 [target.'cfg(target_os = "cuda")'.dependencies]
 rust-cuda = { path = "../../", features = ["derive"] }

--- a/examples/single-source/Cargo.toml
+++ b/examples/single-source/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "7be4521" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "93d3661" }
 
 [target.'cfg(target_os = "cuda")'.dependencies]
 rust-cuda = { path = "../../", features = ["derive"] }

--- a/examples/single-source/Cargo.toml
+++ b/examples/single-source/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "ae040f1" }
+const-type-layout = { git = "https://github.com/MomoLangenstein/const-type-layout", rev = "aa5ad03" }
 
 [target.'cfg(target_os = "cuda")'.dependencies]
 rust-cuda = { path = "../../", features = ["derive"] }

--- a/examples/single-source/src/main.rs
+++ b/examples/single-source/src/main.rs
@@ -26,9 +26,8 @@ fn main() {}
 pub struct Dummy(i32);
 
 #[derive(rust_cuda::common::LendRustToCuda)]
-#[cuda(layout::free = "T")]
 #[allow(dead_code)]
-pub struct Wrapper<T: rust_cuda::common::RustToCuda> {
+pub struct Wrapper<T> {
     #[cuda(embed)]
     inner: T,
 }

--- a/examples/single-source/src/main.rs
+++ b/examples/single-source/src/main.rs
@@ -26,6 +26,7 @@ fn main() {}
 pub struct Dummy(i32);
 
 #[derive(rust_cuda::common::LendRustToCuda)]
+#[r2cLayout(free = "T")]
 #[allow(dead_code)]
 pub struct Wrapper<T: rust_cuda::common::RustToCuda> {
     #[r2cEmbed]

--- a/examples/single-source/src/main.rs
+++ b/examples/single-source/src/main.rs
@@ -26,10 +26,10 @@ fn main() {}
 pub struct Dummy(i32);
 
 #[derive(rust_cuda::common::LendRustToCuda)]
-#[r2cLayout(free = "T")]
+#[cuda(layout::free = "T")]
 #[allow(dead_code)]
 pub struct Wrapper<T: rust_cuda::common::RustToCuda> {
-    #[r2cEmbed]
+    #[cuda(embed)]
     inner: T,
 }
 

--- a/rust-cuda-derive/src/lib.rs
+++ b/rust-cuda-derive/src/lib.rs
@@ -3,6 +3,8 @@
 #![feature(proc_macro_tracked_env)]
 #![feature(proc_macro_span)]
 #![feature(non_exhaustive_omitted_patterns_lint)]
+#![feature(if_let_guard)]
+#![feature(let_chains)]
 #![doc(html_root_url = "https://momolangenstein.github.io/rust-cuda/")]
 
 extern crate proc_macro;
@@ -21,7 +23,7 @@ mod rust_to_cuda;
 //  | rustfmt --config max_width=160 > out.rs
 
 #[proc_macro_error]
-#[proc_macro_derive(LendRustToCuda, attributes(r2cBound, r2cIgnore, r2cEmbed, r2cLayout))]
+#[proc_macro_derive(LendRustToCuda, attributes(cuda))]
 pub fn rust_to_cuda_derive(input: TokenStream) -> TokenStream {
     // Note: We cannot report a more precise span yet
     let ast = match syn::parse(input) {

--- a/rust-cuda-derive/src/lib.rs
+++ b/rust-cuda-derive/src/lib.rs
@@ -21,7 +21,7 @@ mod rust_to_cuda;
 //  | rustfmt --config max_width=160 > out.rs
 
 #[proc_macro_error]
-#[proc_macro_derive(LendRustToCuda, attributes(r2cBound, r2cIgnore, r2cEmbed))]
+#[proc_macro_derive(LendRustToCuda, attributes(r2cBound, r2cIgnore, r2cEmbed, r2cLayout))]
 pub fn rust_to_cuda_derive(input: TokenStream) -> TokenStream {
     // Note: We cannot report a more precise span yet
     let ast = match syn::parse(input) {

--- a/rust-cuda-derive/src/rust_to_cuda/generics.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/generics.rs
@@ -2,9 +2,10 @@ use syn::spanned::Spanned;
 
 pub fn expand_cuda_struct_generics_where_requested_in_attrs(
     ast: &syn::DeriveInput,
-) -> (Vec<syn::Attribute>, syn::Generics) {
+) -> (Vec<syn::Attribute>, syn::Generics, Vec<syn::Attribute>) {
     let mut struct_attrs_cuda = ast.attrs.clone();
     let mut struct_generics_cuda = ast.generics.clone();
+    let mut struct_layout_attrs = Vec::new();
 
     let mut r2c_ignore = false;
 
@@ -51,10 +52,20 @@ pub fn expand_cuda_struct_generics_where_requested_in_attrs(
             r2c_ignore = true;
 
             false
+        } else if attr.path.is_ident("r2cLayout") {
+            struct_layout_attrs.push(syn::Attribute {
+                pound_token: attr.pound_token,
+                style: attr.style,
+                bracket_token: attr.bracket_token,
+                path: proc_macro2::Ident::new("layout", attr.path.span()).into(),
+                tokens: attr.tokens.clone(),
+            });
+
+            false
         } else {
             !r2c_ignore
         }
     });
 
-    (struct_attrs_cuda, struct_generics_cuda)
+    (struct_attrs_cuda, struct_generics_cuda, struct_layout_attrs)
 }

--- a/rust-cuda-derive/src/rust_to_cuda/generics.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/generics.rs
@@ -24,6 +24,10 @@ pub fn expand_cuda_struct_generics_where_requested_in_attrs(
                 .make_where_clause()
                 .predicates
                 .push(bound);
+            struct_generics_cuda
+                .make_where_clause()
+                .predicates
+                .push_punct(syn::token::Comma::default());
 
             false
         } else if attr.path.is_ident("r2cIgnore") {

--- a/rust-cuda-derive/src/rust_to_cuda/generics.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/generics.rs
@@ -24,10 +24,6 @@ pub fn expand_cuda_struct_generics_where_requested_in_attrs(
                 .make_where_clause()
                 .predicates
                 .push(bound);
-            struct_generics_cuda
-                .make_where_clause()
-                .predicates
-                .push_punct(syn::token::Comma::default());
 
             false
         } else if attr.path.is_ident("r2cIgnore") {

--- a/rust-cuda-derive/src/rust_to_cuda/impl.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/impl.rs
@@ -21,6 +21,12 @@ pub fn cuda_struct_declaration(
         quote! { #[repr(C)] }
     };
 
+    let struct_fields_where_clause = if let Some(struct_semi_cuda) = struct_semi_cuda {
+        quote!(#struct_fields_cuda #where_clause #struct_semi_cuda)
+    } else {
+        quote!(#where_clause #struct_fields_cuda)
+    };
+
     quote! {
         #[allow(dead_code)]
         #[doc(hidden)]
@@ -28,8 +34,7 @@ pub fn cuda_struct_declaration(
         #[derive(rust_cuda::const_type_layout::TypeLayout)]
         #struct_repr
         #(#struct_layout_attrs)*
-        #struct_vis_cuda struct #struct_name_cuda #struct_generics_cuda #where_clause
-            #struct_fields_cuda #struct_semi_cuda
+        #struct_vis_cuda struct #struct_name_cuda #struct_generics_cuda #struct_fields_where_clause
 
         // #[derive(DeviceCopy)] can interfer with type parameters
         unsafe impl #impl_generics rust_cuda::rustacuda_core::DeviceCopy

--- a/rust-cuda-derive/src/rust_to_cuda/impl.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/impl.rs
@@ -3,6 +3,7 @@ use quote::quote;
 
 pub fn cuda_struct_declaration(
     struct_attrs_cuda: &[syn::Attribute],
+    struct_layout_attrs: &[syn::Attribute],
     struct_vis_cuda: &syn::Visibility,
     struct_name_cuda: &syn::Ident,
     struct_generics_cuda: &syn::Generics,
@@ -24,8 +25,9 @@ pub fn cuda_struct_declaration(
         #[allow(dead_code)]
         #[doc(hidden)]
         #(#struct_attrs_cuda)*
-        #struct_repr
         #[derive(rust_cuda::const_type_layout::TypeLayout)]
+        #struct_repr
+        #(#struct_layout_attrs)*
         #struct_vis_cuda struct #struct_name_cuda #struct_generics_cuda #where_clause
             #struct_fields_cuda #struct_semi_cuda
 

--- a/rust-cuda-derive/src/rust_to_cuda/mod.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/mod.rs
@@ -62,11 +62,12 @@ pub fn impl_rust_to_cuda(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
         syn::Fields::Unit => (),
     }
 
-    let (struct_attrs_cuda, struct_generics_cuda) =
+    let (struct_attrs_cuda, struct_generics_cuda, struct_layout_attrs) =
         generics::expand_cuda_struct_generics_where_requested_in_attrs(ast);
 
     let cuda_struct_declaration = r#impl::cuda_struct_declaration(
         &struct_attrs_cuda,
+        &struct_layout_attrs,
         &ast.vis,
         &struct_name_cuda,
         &struct_generics_cuda,

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,7 +9,7 @@ use core::ops::{Deref, DerefMut};
 #[cfg(feature = "host")]
 use core::{mem::MaybeUninit, ptr::copy_nonoverlapping};
 
-use const_type_layout::TypeLayout;
+use const_type_layout::TypeGraphLayout;
 use rustacuda_core::DeviceCopy;
 
 #[cfg(feature = "derive")]
@@ -38,7 +38,9 @@ impl<T: CudaAsRust> From<T> for DeviceAccessible<T> {
 }
 
 #[cfg(feature = "host")]
-impl<T: SafeDeviceCopy + TypeLayout> From<&T> for DeviceAccessible<SafeDeviceCopyWrapper<T>> {
+impl<T: SafeDeviceCopy + ~const TypeGraphLayout> From<&T>
+    for DeviceAccessible<SafeDeviceCopyWrapper<T>>
+{
     fn from(value: &T) -> Self {
         let value = unsafe {
             let mut uninit = MaybeUninit::uninit();
@@ -82,7 +84,7 @@ pub unsafe trait RustToCuda {
     #[cfg(feature = "host")]
     #[doc(cfg(feature = "host"))]
     type CudaAllocation: crate::host::CudaAlloc;
-    type CudaRepresentation: CudaAsRust<RustRepresentation = Self>;
+    type CudaRepresentation: CudaAsRust<RustRepresentation = Self> + ~const TypeGraphLayout;
 
     #[cfg(feature = "host")]
     #[doc(cfg(feature = "host"))]
@@ -123,7 +125,7 @@ pub unsafe trait RustToCuda {
 /// # Safety
 ///
 /// This is an internal trait and should NEVER be implemented manually
-pub unsafe trait CudaAsRust: DeviceCopy + TypeLayout {
+pub unsafe trait CudaAsRust: DeviceCopy + ~const TypeGraphLayout {
     type RustRepresentation: RustToCuda<CudaRepresentation = Self>;
 
     #[cfg(any(not(feature = "host"), doc))]

--- a/src/safety/device_copy.rs
+++ b/src/safety/device_copy.rs
@@ -15,7 +15,7 @@ mod sealed {
         for crate::common::DeviceAccessible<T>
     {
     }
-    impl<T: SafeDeviceCopy + const_type_layout::TypeLayout> SafeDeviceCopy
+    impl<T: SafeDeviceCopy + ~const const_type_layout::TypeGraphLayout> SafeDeviceCopy
         for crate::utils::device_copy::SafeDeviceCopyWrapper<T>
     {
     }

--- a/src/utils/box.rs
+++ b/src/utils/box.rs
@@ -17,8 +17,9 @@ use crate::{
 #[repr(transparent)]
 #[derive(TypeLayout)]
 #[allow(clippy::module_name_repetitions)]
-#[layout(bound = "T: SafeDeviceCopy + ~const TypeGraphLayout")]
-pub struct BoxCudaRepresentation<T: SafeDeviceCopy + ~const TypeGraphLayout>(*mut T);
+pub struct BoxCudaRepresentation<T>(*mut T)
+where
+    T: SafeDeviceCopy + ~const TypeGraphLayout;
 
 // Safety: This repr(C) struct only contains a device-owned pointer
 unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> rustacuda_core::DeviceCopy

--- a/src/utils/box.rs
+++ b/src/utils/box.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 
-use const_type_layout::TypeLayout;
+use const_type_layout::TypeGraphLayout;
 
 use crate::{
     common::{CudaAsRust, DeviceAccessible, RustToCuda},
@@ -17,15 +17,16 @@ use crate::{
 #[repr(transparent)]
 #[derive(TypeLayout)]
 #[allow(clippy::module_name_repetitions)]
-pub struct BoxCudaRepresentation<T: SafeDeviceCopy + TypeLayout>(*mut T);
+#[layout(bound = "T: SafeDeviceCopy + ~const TypeGraphLayout")]
+pub struct BoxCudaRepresentation<T: SafeDeviceCopy + ~const TypeGraphLayout>(*mut T);
 
 // Safety: This repr(C) struct only contains a device-owned pointer
-unsafe impl<T: SafeDeviceCopy + TypeLayout> rustacuda_core::DeviceCopy
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> rustacuda_core::DeviceCopy
     for BoxCudaRepresentation<T>
 {
 }
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout> RustToCuda for Box<T> {
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> RustToCuda for Box<T> {
     #[cfg(feature = "host")]
     #[doc(cfg(feature = "host"))]
     type CudaAllocation = CudaDropWrapper<DeviceBox<SafeDeviceCopyWrapper<T>>>;
@@ -70,7 +71,7 @@ unsafe impl<T: SafeDeviceCopy + TypeLayout> RustToCuda for Box<T> {
     }
 }
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout> CudaAsRust for BoxCudaRepresentation<T> {
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> CudaAsRust for BoxCudaRepresentation<T> {
     type RustRepresentation = Box<T>;
 
     #[cfg(any(not(feature = "host"), doc))]

--- a/src/utils/boxed_slice.rs
+++ b/src/utils/boxed_slice.rs
@@ -17,8 +17,9 @@ use crate::{
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, TypeLayout)]
 #[repr(C)]
-#[layout(bound = "T: SafeDeviceCopy + ~const TypeGraphLayout")]
-pub struct BoxedSliceCudaRepresentation<T: SafeDeviceCopy + ~const TypeGraphLayout>(*mut T, usize);
+pub struct BoxedSliceCudaRepresentation<T>(*mut T, usize)
+where
+    T: SafeDeviceCopy + ~const TypeGraphLayout;
 
 // Safety: This repr(C) struct only contains a device-owned pointer
 unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> rustacuda_core::DeviceCopy

--- a/src/utils/boxed_slice.rs
+++ b/src/utils/boxed_slice.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 
-use const_type_layout::TypeLayout;
+use const_type_layout::TypeGraphLayout;
 
 use crate::{
     common::{CudaAsRust, DeviceAccessible, RustToCuda},
@@ -17,15 +17,16 @@ use crate::{
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, TypeLayout)]
 #[repr(C)]
-pub struct BoxedSliceCudaRepresentation<T: SafeDeviceCopy + TypeLayout>(*mut T, usize);
+#[layout(bound = "T: SafeDeviceCopy + ~const TypeGraphLayout")]
+pub struct BoxedSliceCudaRepresentation<T: SafeDeviceCopy + ~const TypeGraphLayout>(*mut T, usize);
 
 // Safety: This repr(C) struct only contains a device-owned pointer
-unsafe impl<T: SafeDeviceCopy + TypeLayout> rustacuda_core::DeviceCopy
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> rustacuda_core::DeviceCopy
     for BoxedSliceCudaRepresentation<T>
 {
 }
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout> RustToCuda for Box<[T]> {
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> RustToCuda for Box<[T]> {
     #[cfg(feature = "host")]
     #[doc(cfg(feature = "host"))]
     type CudaAllocation = CudaDropWrapper<DeviceBuffer<SafeDeviceCopyWrapper<T>>>;
@@ -72,7 +73,9 @@ unsafe impl<T: SafeDeviceCopy + TypeLayout> RustToCuda for Box<[T]> {
     }
 }
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout> CudaAsRust for BoxedSliceCudaRepresentation<T> {
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> CudaAsRust
+    for BoxedSliceCudaRepresentation<T>
+{
     type RustRepresentation = Box<[T]>;
 
     #[cfg(any(not(feature = "host"), doc))]

--- a/src/utils/device_copy.rs
+++ b/src/utils/device_copy.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::trait_duplication_in_bounds)]
 
-use const_type_layout::TypeLayout;
+use const_type_layout::TypeGraphLayout;
 
 use crate::{
     common::{CudaAsRust, DeviceAccessible, RustToCuda},
@@ -9,20 +9,21 @@ use crate::{
 
 #[derive(Copy, Clone, Debug, TypeLayout)]
 #[repr(transparent)]
-pub struct SafeDeviceCopyWrapper<T: SafeDeviceCopy + TypeLayout>(T);
+#[layout(bound = "T: SafeDeviceCopy + ~const TypeGraphLayout")]
+pub struct SafeDeviceCopyWrapper<T: SafeDeviceCopy + ~const TypeGraphLayout>(T);
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout> rustacuda_core::DeviceCopy
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> rustacuda_core::DeviceCopy
     for SafeDeviceCopyWrapper<T>
 {
 }
 
-impl<T: SafeDeviceCopy + TypeLayout> From<T> for SafeDeviceCopyWrapper<T> {
+impl<T: SafeDeviceCopy + ~const TypeGraphLayout> From<T> for SafeDeviceCopyWrapper<T> {
     fn from(value: T) -> Self {
         Self(value)
     }
 }
 
-impl<T: SafeDeviceCopy + TypeLayout> SafeDeviceCopyWrapper<T> {
+impl<T: SafeDeviceCopy + ~const TypeGraphLayout> SafeDeviceCopyWrapper<T> {
     pub fn into_inner(self) -> T {
         self.0
     }
@@ -68,7 +69,7 @@ impl<T: SafeDeviceCopy + TypeLayout> SafeDeviceCopyWrapper<T> {
     }
 }
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout> RustToCuda for SafeDeviceCopyWrapper<T> {
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> RustToCuda for SafeDeviceCopyWrapper<T> {
     #[cfg(feature = "host")]
     type CudaAllocation = crate::host::NullCudaAlloc;
     type CudaRepresentation = Self;
@@ -98,7 +99,7 @@ unsafe impl<T: SafeDeviceCopy + TypeLayout> RustToCuda for SafeDeviceCopyWrapper
     }
 }
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout> CudaAsRust for SafeDeviceCopyWrapper<T> {
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> CudaAsRust for SafeDeviceCopyWrapper<T> {
     type RustRepresentation = Self;
 
     #[cfg(any(not(feature = "host"), doc))]

--- a/src/utils/device_copy.rs
+++ b/src/utils/device_copy.rs
@@ -9,8 +9,9 @@ use crate::{
 
 #[derive(Copy, Clone, Debug, TypeLayout)]
 #[repr(transparent)]
-#[layout(bound = "T: SafeDeviceCopy + ~const TypeGraphLayout")]
-pub struct SafeDeviceCopyWrapper<T: SafeDeviceCopy + ~const TypeGraphLayout>(T);
+pub struct SafeDeviceCopyWrapper<T>(T)
+where
+    T: SafeDeviceCopy + ~const TypeGraphLayout;
 
 unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout> rustacuda_core::DeviceCopy
     for SafeDeviceCopyWrapper<T>

--- a/src/utils/exchange/buffer/common.rs
+++ b/src/utils/exchange/buffer/common.rs
@@ -9,15 +9,12 @@ use super::{CudaExchangeBuffer, CudaExchangeItem};
 #[doc(hidden)]
 #[derive(TypeLayout)]
 #[repr(C)]
-#[layout(bound = "T: SafeDeviceCopy + ~const TypeGraphLayout")]
-pub struct CudaExchangeBufferCudaRepresentation<
-    T: SafeDeviceCopy + ~const TypeGraphLayout,
-    const M2D: bool,
-    const M2H: bool,
->(
+pub struct CudaExchangeBufferCudaRepresentation<T, const M2D: bool, const M2H: bool>(
     pub(super) *mut CudaExchangeItem<T, M2D, M2H>,
     pub(super) usize,
-);
+)
+where
+    T: SafeDeviceCopy + ~const TypeGraphLayout;
 
 // Safety: `CudaExchangeBufferCudaRepresentation<T>` is `DeviceCopy`
 //         iff `T` is `SafeDeviceCopy`

--- a/src/utils/exchange/buffer/common.rs
+++ b/src/utils/exchange/buffer/common.rs
@@ -1,4 +1,4 @@
-use const_type_layout::TypeLayout;
+use const_type_layout::TypeGraphLayout;
 use rustacuda_core::DeviceCopy;
 
 use crate::{common::CudaAsRust, safety::SafeDeviceCopy};
@@ -9,8 +9,9 @@ use super::{CudaExchangeBuffer, CudaExchangeItem};
 #[doc(hidden)]
 #[derive(TypeLayout)]
 #[repr(C)]
+#[layout(bound = "T: SafeDeviceCopy + ~const TypeGraphLayout")]
 pub struct CudaExchangeBufferCudaRepresentation<
-    T: SafeDeviceCopy + TypeLayout,
+    T: SafeDeviceCopy + ~const TypeGraphLayout,
     const M2D: bool,
     const M2H: bool,
 >(
@@ -20,12 +21,12 @@ pub struct CudaExchangeBufferCudaRepresentation<
 
 // Safety: `CudaExchangeBufferCudaRepresentation<T>` is `DeviceCopy`
 //         iff `T` is `SafeDeviceCopy`
-unsafe impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool> DeviceCopy
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout, const M2D: bool, const M2H: bool> DeviceCopy
     for CudaExchangeBufferCudaRepresentation<T, M2D, M2H>
 {
 }
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool> CudaAsRust
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout, const M2D: bool, const M2H: bool> CudaAsRust
     for CudaExchangeBufferCudaRepresentation<T, M2D, M2H>
 {
     type RustRepresentation = CudaExchangeBuffer<T, M2D, M2H>;

--- a/src/utils/exchange/buffer/device.rs
+++ b/src/utils/exchange/buffer/device.rs
@@ -1,6 +1,6 @@
 use core::ops::{Deref, DerefMut};
 
-use const_type_layout::TypeLayout;
+use const_type_layout::TypeGraphLayout;
 
 use crate::{common::RustToCuda, safety::SafeDeviceCopy};
 
@@ -37,7 +37,7 @@ impl<T: SafeDeviceCopy, const M2D: bool, const M2H: bool> DerefMut
 }
 
 #[cfg(not(all(doc, feature = "host")))]
-unsafe impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool> RustToCuda
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout, const M2D: bool, const M2H: bool> RustToCuda
     for CudaExchangeBufferDevice<T, M2D, M2H>
 {
     type CudaRepresentation = CudaExchangeBufferCudaRepresentation<T, M2D, M2H>;

--- a/src/utils/exchange/buffer/host.rs
+++ b/src/utils/exchange/buffer/host.rs
@@ -4,7 +4,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use const_type_layout::TypeLayout;
+use const_type_layout::TypeGraphLayout;
 use rustacuda::{
     error::CudaResult,
     memory::{DeviceBuffer, LockedBuffer},
@@ -26,13 +26,16 @@ use super::{common::CudaExchangeBufferCudaRepresentation, CudaExchangeItem};
 /// [`CudaExchangeBufferDevice`](super::CudaExchangeBufferDevice)
 /// instead.
 /// [`CudaExchangeBufferHost`](Self) is never exposed directly.
-pub struct CudaExchangeBufferHost<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool>
-{
+pub struct CudaExchangeBufferHost<
+    T: SafeDeviceCopy + ~const TypeGraphLayout,
+    const M2D: bool,
+    const M2H: bool,
+> {
     host_buffer: CudaDropWrapper<LockedBuffer<CudaExchangeItem<T, M2D, M2H>>>,
     device_buffer: UnsafeCell<CudaDropWrapper<DeviceBuffer<CudaExchangeItem<T, M2D, M2H>>>>,
 }
 
-impl<T: Clone + SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool>
+impl<T: Clone + SafeDeviceCopy + ~const TypeGraphLayout, const M2D: bool, const M2H: bool>
     CudaExchangeBufferHost<T, M2D, M2H>
 {
     /// # Errors
@@ -53,7 +56,7 @@ impl<T: Clone + SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool>
     }
 }
 
-impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool>
+impl<T: SafeDeviceCopy + ~const TypeGraphLayout, const M2D: bool, const M2H: bool>
     CudaExchangeBufferHost<T, M2D, M2H>
 {
     /// # Errors
@@ -79,7 +82,7 @@ impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool>
     }
 }
 
-impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool> Deref
+impl<T: SafeDeviceCopy + ~const TypeGraphLayout, const M2D: bool, const M2H: bool> Deref
     for CudaExchangeBufferHost<T, M2D, M2H>
 {
     type Target = [CudaExchangeItem<T, M2D, M2H>];
@@ -89,7 +92,7 @@ impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool> Deref
     }
 }
 
-impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool> DerefMut
+impl<T: SafeDeviceCopy + ~const TypeGraphLayout, const M2D: bool, const M2H: bool> DerefMut
     for CudaExchangeBufferHost<T, M2D, M2H>
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -97,7 +100,7 @@ impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool> DerefMut
     }
 }
 
-unsafe impl<T: SafeDeviceCopy + TypeLayout, const M2D: bool, const M2H: bool> RustToCuda
+unsafe impl<T: SafeDeviceCopy + ~const TypeGraphLayout, const M2D: bool, const M2H: bool> RustToCuda
     for CudaExchangeBufferHost<T, M2D, M2H>
 {
     type CudaAllocation = NullCudaAlloc;

--- a/src/utils/option.rs
+++ b/src/utils/option.rs
@@ -1,6 +1,6 @@
 use core::mem::MaybeUninit;
 
-use const_type_layout::TypeLayout;
+use const_type_layout::TypeGraphLayout;
 
 use crate::{
     common::{CudaAsRust, DeviceAccessible, RustToCuda, RustToCudaProxy},
@@ -97,7 +97,7 @@ unsafe impl<T: CudaAsRust> CudaAsRust for OptionCudaRepresentation<T> {
     }
 }
 
-impl<T: SafeDeviceCopy + TypeLayout> RustToCudaProxy<Option<T>>
+impl<T: SafeDeviceCopy + ~const TypeGraphLayout> RustToCudaProxy<Option<T>>
     for Option<SafeDeviceCopyWrapper<T>>
 {
     fn from_ref(val: &Option<T>) -> &Self {


### PR DESCRIPTION
* Switches `#[r2cATTR]` attributes to streamlined `#[cuda(ATTR)]` syntax
* Switches `#[derive(LendToCuda)]` to sensible auto bounds