### PR TITLE
Try switching from rustacuda to cust

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -37,8 +37,9 @@ jobs:
             --enable-index-page \
             --extern-html-root-url const_type_layout=https://docs.rs/const-type-layout/0.3.2/ \
             --extern-html-root-url final=https://docs.rs/final/0.1.1/ \
-            --extern-html-root-url rustacuda=https://docs.rs/rustacuda/0.1.3/ \
-            --extern-html-root-url rustacuda_core=https://docs.rs/rustacuda_core/0.1.2/ \
+            --extern-html-root-url cust=https://docs.rs/cust/0.3.2/ \
+            --extern-html-root-url cust_core=https://docs.rs/cust_core/0.1/ \
+            --extern-html-root-url cust_derive=https://docs.rs/cust_derive/0.2/ \
             -Zunstable-options \
           " cargo doc \
             --all-features \

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -39,7 +39,6 @@ jobs:
             --extern-html-root-url final=https://docs.rs/final/0.1.1/ \
             --extern-html-root-url cust=https://docs.rs/cust/0.3.2/ \
             --extern-html-root-url cust_core=https://docs.rs/cust_core/0.1/ \
-            --extern-html-root-url cust_derive=https://docs.rs/cust_derive/0.2/ \
             -Zunstable-options \
           " cargo doc \
             --all-features \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ rust-cuda-kernel = { version = "0.1", path = "rust-cuda-kernel", default-feature
 # third-party dependencies with unpublished patches
 cust = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.3.2", default-features = false }
 cust_core = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.1", default-features = false }
-cust_derive = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.2", default-features = false }
 
 # crates.io third-party dependencies
 cargo_metadata = { version = "0.19", default-features = false }
@@ -90,7 +89,7 @@ rust-version = { workspace = true }
 
 [features]
 default = []
-derive = ["dep:cust_derive", "dep:rust-cuda-derive"]
+derive = ["dep:rust-cuda-derive"]
 device = []
 final = ["dep:final"]
 host = ["dep:cust", "dep:regex", "dep:oneshot", "dep:safer_owning_ref"]
@@ -100,10 +99,12 @@ kernel = ["dep:rust-cuda-kernel"]
 const-type-layout = { workspace = true, features = ["derive"] }
 cust = { workspace = true, optional = true }
 cust_core = { workspace = true }
-cust_derive = { workspace = true, optional = true }
 final = { workspace = true, optional = true }
 oneshot = { workspace = true, features = ["std", "async"], optional = true }
 regex = { workspace = true, optional = true }
 rust-cuda-derive = { workspace = true, optional = true }
 rust-cuda-kernel = { workspace = true, optional = true }
 safer_owning_ref = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,13 @@ rust-cuda-derive = { version = "0.1", path = "rust-cuda-derive", default-feature
 rust-cuda-kernel = { version = "0.1", path = "rust-cuda-kernel", default-features = false }
 
 # third-party dependencies with unpublished patches
-rustacuda = { git = "https://github.com/juntyr/RustaCUDA", rev = "c6ea7cc", default-features = false }
-rustacuda_core = { git = "https://github.com/juntyr/RustaCUDA", rev = "c6ea7cc", default-features = false }
+cust = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.3.2", default-features = false }
+cust_core = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.1", default-features = false }
+cust_derive = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.2", default-features = false }
 
 # crates.io third-party dependencies
 cargo_metadata = { version = "0.19", default-features = false }
-cargo-util = { version = "=0.2.16", default-features = false }  # TODO: keep in sync with toolchain
+cargo-util = { version = "=0.2.17", default-features = false }  # TODO: keep in sync with toolchain
 colored = { version = "3.0", default-features = false }
 const-type-layout = { version = "0.3.2", default-features = false }
 final = { version = "0.1.1", default-features = false }
@@ -96,14 +97,13 @@ host = ["dep:cust", "dep:regex", "dep:oneshot", "dep:safer_owning_ref"]
 kernel = ["dep:rust-cuda-kernel"]
 
 [dependencies]
-const-type-layout = { version = "0.3.2", default-features = false, features = ["derive"] }
-cust = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.3.2", default-features = false, optional = true }
-cust_core = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.1", default-features = false }
-cust_derive = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.2", default-features = false, optional = true }
-final = { version = "0.1.1", default-features = false, optional = true }
-oneshot = { version = "0.1", default-features = false, features = ["std", "async"], optional = true }
-regex = { version = "1.10", default-features = false, optional = true }
-safer_owning_ref = { version = "0.5", default-features = false, optional = true }
-
-rust-cuda-derive = { path = "rust-cuda-derive", default-features = false, optional = true }
-rust-cuda-kernel = { path = "rust-cuda-kernel", default-features = false, optional = true }
+const-type-layout = { workspace = true, features = ["derive"] }
+cust = { workspace = true, optional = true }
+cust_core = { workspace = true }
+cust_derive = { workspace = true, optional = true }
+final = { workspace = true, optional = true }
+oneshot = { workspace = true, features = ["std", "async"], optional = true }
+regex = { workspace = true, optional = true }
+rust-cuda-derive = { workspace = true, optional = true }
+rust-cuda-kernel = { workspace = true, optional = true }
+safer_owning_ref = { workspace = true, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 authors = ["Juniper Tyree <juniper.tyree@helsinki.fi>"]
 repository = "https://github.com/juntyr/rust-cuda"
 license = "MIT OR Apache-2.0"
-rust-version = "1.81" # nightly
+rust-version = "1.84" # nightly
 
 [workspace.dependencies]
 # workspace-internal crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,7 @@ kernel = ["dep:rust-cuda-kernel"]
 
 [dependencies]
 const-type-layout = { version = "0.3.2", default-features = false, features = ["derive"] }
-# FIXME: cust fails to compile without the `bytemuck` feature
-cust = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.3.2", default-features = false, features = ["bytemuck"], optional = true }
+cust = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.3.2", default-features = false, optional = true }
 cust_core = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.1", default-features = false }
 cust_derive = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.2", default-features = false, optional = true }
 final = { version = "0.1.1", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,9 +98,9 @@ kernel = ["dep:rust-cuda-kernel"]
 [dependencies]
 const-type-layout = { version = "0.3.2", default-features = false, features = ["derive"] }
 # FIXME: cust fails to compile without the `bytemuck` feature
-cust = { version = "0.3.2", default-features = false, features = ["bytemuck"], optional = true }
-cust_core = { version = "0.1", default-features = false }
-cust_derive = { version = "0.2", default-features = false, optional = true }
+cust = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.3.2", default-features = false, features = ["bytemuck"], optional = true }
+cust_core = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.1", default-features = false }
+cust_derive = { git = "https://github.com/juntyr/Rust-GPU-CUDA.git", rev = "5365c14", version = "0.2", default-features = false, optional = true }
 final = { version = "0.1.1", default-features = false, optional = true }
 oneshot = { version = "0.1", default-features = false, features = ["std", "async"], optional = true }
 regex = { version = "1.10", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,22 +89,22 @@ rust-version = { workspace = true }
 
 [features]
 default = []
-derive = ["dep:rust-cuda-derive"]
+derive = ["dep:cust_derive", "dep:rust-cuda-derive"]
 device = []
 final = ["dep:final"]
-host = ["dep:rustacuda", "dep:regex", "dep:oneshot", "dep:safer_owning_ref"]
+host = ["dep:cust", "dep:regex", "dep:oneshot", "dep:safer_owning_ref"]
 kernel = ["dep:rust-cuda-kernel"]
 
 [dependencies]
-const-type-layout = { workspace = true, features = ["derive"] }
-final = { workspace = true, optional = true }
-oneshot = { workspace = true, features = ["std", "async"], optional = true }
-regex = { workspace = true, optional = true }
-rustacuda = { workspace = true, optional = true }
-rustacuda_core = { workspace = true }
-rust-cuda-derive = { workspace = true, optional = true }
-rust-cuda-kernel = { workspace = true, optional = true }
-safer_owning_ref = { workspace = true, optional = true }
+const-type-layout = { version = "0.3.2", default-features = false, features = ["derive"] }
+# FIXME: cust fails to compile without the `bytemuck` feature
+cust = { version = "0.3.2", default-features = false, features = ["bytemuck"], optional = true }
+cust_core = { version = "0.1", default-features = false }
+cust_derive = { version = "0.2", default-features = false, optional = true }
+final = { version = "0.1.1", default-features = false, optional = true }
+oneshot = { version = "0.1", default-features = false, features = ["std", "async"], optional = true }
+regex = { version = "1.10", default-features = false, optional = true }
+safer_owning_ref = { version = "0.5", default-features = false, optional = true }
 
-[lints]
-workspace = true
+rust-cuda-derive = { path = "rust-cuda-derive", default-features = false, optional = true }
+rust-cuda-kernel = { path = "rust-cuda-kernel", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/rust-cuda/ci.yml?branch=main
 [workflow]: https://github.com/juntyr/rust-cuda/actions/workflows/ci.yml?query=branch%3Amain
 
-[MSRV]: https://img.shields.io/badge/MSRV-1.81.0--nightly-orange
+[MSRV]: https://img.shields.io/badge/MSRV-1.84.0--nightly-orange
 [repo]: https://github.com/juntyr/rust-cuda
 
 [Rust Doc]: https://img.shields.io/badge/docs-main-blue

--- a/examples/lifetime/src/main.rs
+++ b/examples/lifetime/src/main.rs
@@ -2,30 +2,30 @@
 
 use lifetime::{kernel, link};
 
-fn main() -> rust_cuda::deps::rustacuda::error::CudaResult<()> {
+fn main() -> rust_cuda::deps::cust::error::CudaResult<()> {
     // Link the lifetime-only-generic CUDA kernel
     struct KernelPtx<'a, 'b>(core::marker::PhantomData<(&'a (), &'b ())>);
     link! { impl kernel<'a, 'b> for KernelPtx }
 
     // Initialize the CUDA API
-    rust_cuda::deps::rustacuda::init(rust_cuda::deps::rustacuda::CudaFlags::empty())?;
+    rust_cuda::deps::cust::init(rust_cuda::deps::cust::CudaFlags::empty())?;
 
     // Get the first CUDA GPU device
-    let device = rust_cuda::deps::rustacuda::device::Device::get_device(0)?;
+    let device = rust_cuda::deps::cust::device::Device::get_device(0)?;
 
     // Create a CUDA context associated to this device
     let _context = rust_cuda::host::CudaDropWrapper::from(
-        rust_cuda::deps::rustacuda::context::Context::create_and_push(
-            rust_cuda::deps::rustacuda::context::ContextFlags::MAP_HOST
-                | rust_cuda::deps::rustacuda::context::ContextFlags::SCHED_AUTO,
+        rust_cuda::deps::cust::context::legacy::Context::create_and_push(
+            rust_cuda::deps::cust::context::legacy::ContextFlags::MAP_HOST
+                | rust_cuda::deps::cust::context::legacy::ContextFlags::SCHED_AUTO,
             device,
         )?,
     );
 
     // Create a new CUDA stream to submit kernels to
     let mut stream =
-        rust_cuda::host::CudaDropWrapper::from(rust_cuda::deps::rustacuda::stream::Stream::new(
-            rust_cuda::deps::rustacuda::stream::StreamFlags::NON_BLOCKING,
+        rust_cuda::host::CudaDropWrapper::from(rust_cuda::deps::cust::stream::Stream::new(
+            rust_cuda::deps::cust::stream::StreamFlags::NON_BLOCKING,
             None,
         )?);
 
@@ -34,8 +34,8 @@ fn main() -> rust_cuda::deps::rustacuda::error::CudaResult<()> {
     // Create a new instance of the CUDA kernel and prepare the launch config
     let mut kernel = rust_cuda::kernel::TypedPtxKernel::<kernel>::new::<KernelPtx>(None);
     let config = rust_cuda::kernel::LaunchConfig {
-        grid: rust_cuda::deps::rustacuda::function::GridSize::x(1),
-        block: rust_cuda::deps::rustacuda::function::BlockSize::x(4),
+        grid: rust_cuda::deps::cust::function::GridSize::x(1),
+        block: rust_cuda::deps::cust::function::BlockSize::x(4),
         ptx_jit: false,
     };
 

--- a/examples/print/src/main.rs
+++ b/examples/print/src/main.rs
@@ -2,38 +2,38 @@
 
 use print::{kernel, link, Action};
 
-fn main() -> rust_cuda::deps::rustacuda::error::CudaResult<()> {
+fn main() -> rust_cuda::deps::cust::error::CudaResult<()> {
     // Link the non-generic CUDA kernel
     struct KernelPtx;
     link! { impl kernel for KernelPtx }
 
     // Initialize the CUDA API
-    rust_cuda::deps::rustacuda::init(rust_cuda::deps::rustacuda::CudaFlags::empty())?;
+    rust_cuda::deps::cust::init(rust_cuda::deps::cust::CudaFlags::empty())?;
 
     // Get the first CUDA GPU device
-    let device = rust_cuda::deps::rustacuda::device::Device::get_device(0)?;
+    let device = rust_cuda::deps::cust::device::Device::get_device(0)?;
 
     // Create a CUDA context associated to this device
     let _context = rust_cuda::host::CudaDropWrapper::from(
-        rust_cuda::deps::rustacuda::context::Context::create_and_push(
-            rust_cuda::deps::rustacuda::context::ContextFlags::MAP_HOST
-                | rust_cuda::deps::rustacuda::context::ContextFlags::SCHED_AUTO,
+        rust_cuda::deps::cust::context::Context::create_and_push(
+            rust_cuda::deps::cust::context::ContextFlags::MAP_HOST
+                | rust_cuda::deps::cust::context::ContextFlags::SCHED_AUTO,
             device,
         )?,
     );
 
     // Create a new CUDA stream to submit kernels to
     let mut stream =
-        rust_cuda::host::CudaDropWrapper::from(rust_cuda::deps::rustacuda::stream::Stream::new(
-            rust_cuda::deps::rustacuda::stream::StreamFlags::NON_BLOCKING,
+        rust_cuda::host::CudaDropWrapper::from(rust_cuda::deps::cust::stream::Stream::new(
+            rust_cuda::deps::cust::stream::StreamFlags::NON_BLOCKING,
             None,
         )?);
 
     // Create a new instance of the CUDA kernel and prepare the launch config
     let mut kernel = rust_cuda::kernel::TypedPtxKernel::<kernel>::new::<KernelPtx>(None);
     let config = rust_cuda::kernel::LaunchConfig {
-        grid: rust_cuda::deps::rustacuda::function::GridSize::x(1),
-        block: rust_cuda::deps::rustacuda::function::BlockSize::x(4),
+        grid: rust_cuda::deps::cust::function::GridSize::x(1),
+        block: rust_cuda::deps::cust::function::BlockSize::x(4),
         ptx_jit: false,
     };
 

--- a/examples/print/src/main.rs
+++ b/examples/print/src/main.rs
@@ -15,9 +15,9 @@ fn main() -> rust_cuda::deps::cust::error::CudaResult<()> {
 
     // Create a CUDA context associated to this device
     let _context = rust_cuda::host::CudaDropWrapper::from(
-        rust_cuda::deps::cust::context::Context::create_and_push(
-            rust_cuda::deps::cust::context::ContextFlags::MAP_HOST
-                | rust_cuda::deps::cust::context::ContextFlags::SCHED_AUTO,
+        rust_cuda::deps::cust::context::legacy::Context::create_and_push(
+            rust_cuda::deps::cust::context::legacy::ContextFlags::MAP_HOST
+                | rust_cuda::deps::cust::context::legacy::ContextFlags::SCHED_AUTO,
             device,
         )?,
     );

--- a/rust-cuda-derive/src/lib.rs
+++ b/rust-cuda-derive/src/lib.rs
@@ -5,7 +5,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/rust-cuda/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/rust-cuda/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.81.0--nightly-orange
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.84.0--nightly-orange
 //! [repo]: https://github.com/juntyr/rust-cuda
 //!
 //! [Rust Doc]: https://img.shields.io/badge/docs-main-blue

--- a/rust-cuda-derive/src/rust_to_cuda/field_ty.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/field_ty.rs
@@ -1,6 +1,5 @@
 use syn::{parse_quote, spanned::Spanned};
 
-#[expect(clippy::module_name_repetitions)]
 pub enum CudaReprFieldTy {
     SafeDeviceCopy,
     RustToCuda {

--- a/rust-cuda-derive/src/rust_to_cuda/impl.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/impl.rs
@@ -84,7 +84,7 @@ pub fn rust_to_cuda_trait(
             unsafe fn borrow<CudaAllocType: #crate_path::alloc::CudaAlloc>(
                 &self,
                 alloc: CudaAllocType,
-            ) -> #crate_path::deps::rustacuda::error::CudaResult<(
+            ) -> #crate_path::deps::cust::error::CudaResult<(
                 #crate_path::utils::ffi::DeviceAccessible<Self::CudaRepresentation>,
                 #crate_path::alloc::CombinedCudaAlloc<Self::CudaAllocation, CudaAllocType>
             )> {
@@ -107,7 +107,7 @@ pub fn rust_to_cuda_trait(
                 alloc: #crate_path::alloc::CombinedCudaAlloc<
                     Self::CudaAllocation, CudaAllocType
                 >,
-            ) -> #crate_path::deps::rustacuda::error::CudaResult<CudaAllocType> {
+            ) -> #crate_path::deps::cust::error::CudaResult<CudaAllocType> {
                 let (alloc_front, alloc_tail) = alloc.split();
 
                 #(#r2c_field_destructors)*
@@ -192,7 +192,7 @@ pub fn rust_to_cuda_async_trait(
                 &self,
                 alloc: CudaAllocType,
                 stream: #crate_path::host::Stream<'stream>,
-            ) -> #crate_path::deps::rustacuda::error::CudaResult<(
+            ) -> #crate_path::deps::cust::error::CudaResult<(
                 #crate_path::utils::r#async::Async<
                     '_, 'stream,
                     #crate_path::utils::ffi::DeviceAccessible<Self::CudaRepresentation>,
@@ -220,7 +220,7 @@ pub fn rust_to_cuda_async_trait(
                     Self::CudaAllocationAsync, CudaAllocType
                 >,
                 stream: #crate_path::host::Stream<'stream>,
-            ) -> #crate_path::deps::rustacuda::error::CudaResult<(
+            ) -> #crate_path::deps::cust::error::CudaResult<(
                 #crate_path::utils::r#async::Async<
                     'a, 'stream,
                     #crate_path::deps::owning_ref::BoxRefMut<'a, CudaRestoreOwner, Self>,

--- a/rust-cuda-derive/src/rust_to_cuda/mod.rs
+++ b/rust-cuda-derive/src/rust_to_cuda/mod.rs
@@ -10,7 +10,7 @@ fn get_cuda_repr_ident(rust_repr_ident: &proc_macro2::Ident) -> proc_macro2::Ide
     format_ident!("{}CudaRepresentation", rust_repr_ident)
 }
 
-#[expect(clippy::module_name_repetitions, clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn impl_rust_to_cuda(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
     let (mut struct_fields_cuda, struct_semi_cuda) = if let syn::Data::Struct(s) = &ast.data {
         (s.fields.clone(), s.semi_token)

--- a/rust-cuda-kernel/build.rs
+++ b/rust-cuda-kernel/build.rs
@@ -5,7 +5,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/rust-cuda/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/rust-cuda/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.81.0--nightly-orange
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.84.0--nightly-orange
 //! [repo]: https://github.com/juntyr/rust-cuda
 //!
 //! [Rust Doc]: https://img.shields.io/badge/docs-main-blue

--- a/rust-cuda-kernel/src/kernel/link/mod.rs
+++ b/rust-cuda-kernel/src/kernel/link/mod.rs
@@ -189,7 +189,6 @@ fn extract_ptx_kernel_layout(kernel_ptx: &mut String) -> proc_macro2::TokenStrea
             );
         }
 
-        #[allow(clippy::literal_string_with_formatting_args)] // false positive
         if type_layout_metas
             .insert(String::from(param), bytes)
             .is_some()
@@ -484,7 +483,7 @@ fn check_kernel_ptx(
             }
             if ptx_lint_levels
                 .get(&PtxLint::DynamicStackSize)
-                .map_or(true, |level| *level <= LintLevel::Warn)
+                .is_none_or(|level| *level <= LintLevel::Warn)
             {
                 options.push(c"--suppress-stack-size-warning");
             }
@@ -530,7 +529,7 @@ fn check_kernel_ptx(
         }
         if ptx_lint_levels
             .get(&PtxLint::DynamicStackSize)
-            .map_or(true, |level| *level < LintLevel::Warn)
+            .is_none_or(|level| *level < LintLevel::Warn)
         {
             options.push(c"--suppress-stack-size-warning");
         }

--- a/rust-cuda-kernel/src/kernel/link/mod.rs
+++ b/rust-cuda-kernel/src/kernel/link/mod.rs
@@ -321,7 +321,8 @@ fn check_kernel_ptx_and_report(
         Ok(None) => (),
         Ok(Some(binary)) => {
             if ptx_lint_levels
-                .get(&PtxLint::DumpAssembly).is_some_and(|level| *level > LintLevel::Allow)
+                .get(&PtxLint::DumpAssembly)
+                .is_some_and(|level| *level > LintLevel::Allow)
             {
                 const HEX: [char; 16] = [
                     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
@@ -335,7 +336,8 @@ fn check_kernel_ptx_and_report(
                 }
 
                 if ptx_lint_levels
-                    .get(&PtxLint::DumpAssembly).is_some_and(|level| *level > LintLevel::Warn)
+                    .get(&PtxLint::DumpAssembly)
+                    .is_some_and(|level| *level > LintLevel::Warn)
                 {
                     emit_call_site_error!(
                         "{} compiled binary:\n{}\n\n{}",
@@ -457,22 +459,27 @@ fn check_kernel_ptx(
             let mut options = options.clone();
 
             if ptx_lint_levels
-                .get(&PtxLint::Verbose).is_some_and(|level| *level > LintLevel::Warn)
+                .get(&PtxLint::Verbose)
+                .is_some_and(|level| *level > LintLevel::Warn)
             {
                 options.push(c"--verbose");
             }
             if ptx_lint_levels
-                .get(&PtxLint::DoublePrecisionUse).is_some_and(|level| *level > LintLevel::Warn)
+                .get(&PtxLint::DoublePrecisionUse)
+                .is_some_and(|level| *level > LintLevel::Warn)
             {
                 options.push(c"--warn-on-double-precision-use");
             }
             if ptx_lint_levels
-                .get(&PtxLint::LocalMemoryUse).is_some_and(|level| *level > LintLevel::Warn)
+                .get(&PtxLint::LocalMemoryUse)
+                .is_some_and(|level| *level > LintLevel::Warn)
             {
                 options.push(c"--warn-on-local-memory-usage");
             }
             if ptx_lint_levels
-                .get(&PtxLint::RegisterSpills).is_some_and(|level| *level > LintLevel::Warn) {
+                .get(&PtxLint::RegisterSpills)
+                .is_some_and(|level| *level > LintLevel::Warn)
+            {
                 options.push(c"--warn-on-spills");
             }
             if ptx_lint_levels
@@ -498,21 +505,26 @@ fn check_kernel_ptx(
         };
 
         if ptx_lint_levels
-            .get(&PtxLint::Verbose).is_some_and(|level| *level > LintLevel::Allow)
+            .get(&PtxLint::Verbose)
+            .is_some_and(|level| *level > LintLevel::Allow)
         {
             options.push(c"--verbose");
         }
         if ptx_lint_levels
-            .get(&PtxLint::DoublePrecisionUse).is_some_and(|level| *level > LintLevel::Allow) {
+            .get(&PtxLint::DoublePrecisionUse)
+            .is_some_and(|level| *level > LintLevel::Allow)
+        {
             options.push(c"--warn-on-double-precision-use");
         }
         if ptx_lint_levels
-            .get(&PtxLint::LocalMemoryUse).is_some_and(|level| *level > LintLevel::Allow)
+            .get(&PtxLint::LocalMemoryUse)
+            .is_some_and(|level| *level > LintLevel::Allow)
         {
             options.push(c"--warn-on-local-memory-usage");
         }
         if ptx_lint_levels
-            .get(&PtxLint::RegisterSpills).is_some_and(|level| *level > LintLevel::Allow)
+            .get(&PtxLint::RegisterSpills)
+            .is_some_and(|level| *level > LintLevel::Allow)
         {
             options.push(c"--warn-on-spills");
         }

--- a/rust-cuda-kernel/src/kernel/link/mod.rs
+++ b/rust-cuda-kernel/src/kernel/link/mod.rs
@@ -189,6 +189,7 @@ fn extract_ptx_kernel_layout(kernel_ptx: &mut String) -> proc_macro2::TokenStrea
             );
         }
 
+        #[allow(clippy::literal_string_with_formatting_args)] // false positive
         if type_layout_metas
             .insert(String::from(param), bytes)
             .is_some()
@@ -320,8 +321,7 @@ fn check_kernel_ptx_and_report(
         Ok(None) => (),
         Ok(Some(binary)) => {
             if ptx_lint_levels
-                .get(&PtxLint::DumpAssembly)
-                .map_or(false, |level| *level > LintLevel::Allow)
+                .get(&PtxLint::DumpAssembly).is_some_and(|level| *level > LintLevel::Allow)
             {
                 const HEX: [char; 16] = [
                     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
@@ -335,8 +335,7 @@ fn check_kernel_ptx_and_report(
                 }
 
                 if ptx_lint_levels
-                    .get(&PtxLint::DumpAssembly)
-                    .map_or(false, |level| *level > LintLevel::Warn)
+                    .get(&PtxLint::DumpAssembly).is_some_and(|level| *level > LintLevel::Warn)
                 {
                     emit_call_site_error!(
                         "{} compiled binary:\n{}\n\n{}",
@@ -458,27 +457,22 @@ fn check_kernel_ptx(
             let mut options = options.clone();
 
             if ptx_lint_levels
-                .get(&PtxLint::Verbose)
-                .map_or(false, |level| *level > LintLevel::Warn)
+                .get(&PtxLint::Verbose).is_some_and(|level| *level > LintLevel::Warn)
             {
                 options.push(c"--verbose");
             }
             if ptx_lint_levels
-                .get(&PtxLint::DoublePrecisionUse)
-                .map_or(false, |level| *level > LintLevel::Warn)
+                .get(&PtxLint::DoublePrecisionUse).is_some_and(|level| *level > LintLevel::Warn)
             {
                 options.push(c"--warn-on-double-precision-use");
             }
             if ptx_lint_levels
-                .get(&PtxLint::LocalMemoryUse)
-                .map_or(false, |level| *level > LintLevel::Warn)
+                .get(&PtxLint::LocalMemoryUse).is_some_and(|level| *level > LintLevel::Warn)
             {
                 options.push(c"--warn-on-local-memory-usage");
             }
             if ptx_lint_levels
-                .get(&PtxLint::RegisterSpills)
-                .map_or(false, |level| *level > LintLevel::Warn)
-            {
+                .get(&PtxLint::RegisterSpills).is_some_and(|level| *level > LintLevel::Warn) {
                 options.push(c"--warn-on-spills");
             }
             if ptx_lint_levels
@@ -504,26 +498,21 @@ fn check_kernel_ptx(
         };
 
         if ptx_lint_levels
-            .get(&PtxLint::Verbose)
-            .map_or(false, |level| *level > LintLevel::Allow)
+            .get(&PtxLint::Verbose).is_some_and(|level| *level > LintLevel::Allow)
         {
             options.push(c"--verbose");
         }
         if ptx_lint_levels
-            .get(&PtxLint::DoublePrecisionUse)
-            .map_or(false, |level| *level > LintLevel::Allow)
-        {
+            .get(&PtxLint::DoublePrecisionUse).is_some_and(|level| *level > LintLevel::Allow) {
             options.push(c"--warn-on-double-precision-use");
         }
         if ptx_lint_levels
-            .get(&PtxLint::LocalMemoryUse)
-            .map_or(false, |level| *level > LintLevel::Allow)
+            .get(&PtxLint::LocalMemoryUse).is_some_and(|level| *level > LintLevel::Allow)
         {
             options.push(c"--warn-on-local-memory-usage");
         }
         if ptx_lint_levels
-            .get(&PtxLint::RegisterSpills)
-            .map_or(false, |level| *level > LintLevel::Allow)
+            .get(&PtxLint::RegisterSpills).is_some_and(|level| *level > LintLevel::Allow)
         {
             options.push(c"--warn-on-spills");
         }

--- a/rust-cuda-kernel/src/kernel/lints.rs
+++ b/rust-cuda-kernel/src/kernel/lints.rs
@@ -180,7 +180,7 @@ pub trait NestedMetaParser {
     ) -> syn::Result<()>;
 }
 
-impl<'a> NestedMetaParser for syn::meta::ParseNestedMeta<'a> {
+impl NestedMetaParser for syn::meta::ParseNestedMeta<'_> {
     fn path(&self) -> &syn::Path {
         &self.path
     }

--- a/rust-cuda-kernel/src/lib.rs
+++ b/rust-cuda-kernel/src/lib.rs
@@ -5,7 +5,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/rust-cuda/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/rust-cuda/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.81.0--nightly-orange
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.84.0--nightly-orange
 //! [repo]: https://github.com/juntyr/rust-cuda
 //!
 //! [Rust Doc]: https://img.shields.io/badge/docs-main-blue

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-# Pin to final 1.85.0 nightly
-channel = "nightly-2025-01-03"
+# Pin to final 1.84.0 nightly
+channel = "nightly-2024-11-22"
 components = [ "cargo", "rustfmt", "clippy", "llvm-bitcode-linker", "llvm-tools" ]
 targets = [ "nvptx64-nvidia-cuda" ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-# Pin to final 1.81.0 nightly
-channel = "nightly-2024-07-21"
+# Pin to final 1.85.0 nightly
+channel = "nightly-2025-01-03"
 components = [ "cargo", "rustfmt", "clippy", "llvm-bitcode-linker", "llvm-tools" ]
-targets = [ "x86_64-unknown-linux-gnu", "nvptx64-nvidia-cuda" ]
+targets = [ "nvptx64-nvidia-cuda" ]

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -7,6 +7,6 @@ pub extern crate const_type_layout;
 pub extern crate owning_ref;
 
 #[cfg(feature = "host")]
-pub extern crate rustacuda;
+pub extern crate cust;
 
-pub extern crate rustacuda_core;
+pub extern crate cust_core;

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -205,6 +205,7 @@ impl<'a, T: PortableBitSemantics + TypeGraphLayout> HostAndDeviceMutRef<'a, T> {
         }
     }
 
+    #[allow(clippy::needless_pass_by_ref_mut)]
     #[must_use]
     pub(crate) fn for_device<'b>(&'b mut self) -> DeviceMutRef<'a, T>
     where
@@ -244,18 +245,15 @@ impl<'a, T: PortableBitSemantics + TypeGraphLayout> HostAndDeviceMutRef<'a, T> {
     }
 
     #[must_use]
-    pub fn into_mut<'b>(self) -> HostAndDeviceMutRef<'b, T>
+    pub const fn into_mut<'b>(self) -> HostAndDeviceMutRef<'b, T>
     where
         'a: 'b,
     {
-        HostAndDeviceMutRef {
-            device_box: self.device_box,
-            host_ref: self.host_ref,
-        }
+        self
     }
 
     #[must_use]
-    pub fn into_async<'b, 'stream>(
+    pub const fn into_async<'b, 'stream>(
         self,
         stream: Stream<'stream>,
     ) -> Async<'b, 'stream, HostAndDeviceMutRef<'b, T>, NoCompletion>

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -35,7 +35,7 @@ pub struct Stream<'stream> {
     _brand: InvariantLifetime<'stream>,
 }
 
-impl<'stream> Deref for Stream<'stream> {
+impl Deref for Stream<'_> {
     type Target = cust::stream::Stream;
 
     fn deref(&self) -> &Self::Target {
@@ -43,7 +43,7 @@ impl<'stream> Deref for Stream<'stream> {
     }
 }
 
-impl<'stream> Stream<'stream> {
+impl Stream<'_> {
     /// Create a new uniquely branded [`Stream`], which can bind async
     /// operations to the [`Stream`] that they are computed on.
     ///
@@ -152,6 +152,7 @@ macro_rules! impl_sealed_drop_value {
 impl_sealed_drop_value!(Module);
 impl_sealed_drop_value!(cust::stream::Stream);
 impl_sealed_drop_value!(Context);
+impl_sealed_drop_value!(cust::context::legacy::Context);
 impl_sealed_drop_value!(Event);
 
 #[expect(clippy::module_name_repetitions)]
@@ -271,13 +272,13 @@ pub struct HostAndDeviceConstRef<'a, T: PortableBitSemantics + TypeGraphLayout> 
     host_ref: &'a T,
 }
 
-impl<'a, T: PortableBitSemantics + TypeGraphLayout> Clone for HostAndDeviceConstRef<'a, T> {
+impl<T: PortableBitSemantics + TypeGraphLayout> Clone for HostAndDeviceConstRef<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, T: PortableBitSemantics + TypeGraphLayout> Copy for HostAndDeviceConstRef<'a, T> {}
+impl<T: PortableBitSemantics + TypeGraphLayout> Copy for HostAndDeviceConstRef<'_, T> {}
 
 impl<'a, T: PortableBitSemantics + TypeGraphLayout> HostAndDeviceConstRef<'a, T> {
     /// # Errors

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -9,10 +9,9 @@ use cust::{
     context::Context,
     error::CudaError,
     event::Event,
-    memory::{CopyDestination, DeviceBox, DeviceBuffer, LockedBox, LockedBuffer},
+    memory::{CopyDestination, DeviceBox, DeviceBuffer, DeviceCopy, LockedBox, LockedBuffer},
     module::Module,
 };
-use cust_core::DeviceCopy;
 
 use crate::{
     safety::PortableBitSemantics,
@@ -119,7 +118,7 @@ impl<T: DeviceCopy> CudaDroppable for DeviceBox<T> {
     }
 }
 
-impl<T: cust_core::DeviceCopy> CudaDroppable for DeviceBuffer<T> {
+impl<T: DeviceCopy> CudaDroppable for DeviceBuffer<T> {
     fn drop(val: Self) -> Result<(), (CudaError, Self)> {
         Self::drop(val)
     }
@@ -133,7 +132,7 @@ impl<T: DeviceCopy> CudaDroppable for LockedBox<T> {
     }
 }
 
-impl<T: cust_core::DeviceCopy> CudaDroppable for LockedBuffer<T> {
+impl<T: DeviceCopy> CudaDroppable for LockedBuffer<T> {
     fn drop(val: Self) -> Result<(), (CudaError, Self)> {
         Self::drop(val)
     }

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -7,12 +7,11 @@ use std::{
     ptr::NonNull,
 };
 
-use cust::module::{ModuleJitOption, OptLevel};
 #[cfg(feature = "host")]
 use cust::{
     error::{CudaError, CudaResult},
     function::Function,
-    module::Module,
+    module::{Module, ModuleJitOption, OptLevel},
 };
 
 #[cfg(feature = "kernel")]
@@ -226,7 +225,7 @@ macro_rules! impl_launcher_launch {
 }
 
 #[cfg(feature = "host")]
-impl<'stream, 'kernel, Kernel> Launcher<'stream, 'kernel, Kernel> {
+impl<'stream, Kernel> Launcher<'stream, '_, Kernel> {
     impl_launcher_launch! { launch0() => with0_async => launch0_async }
 
     impl_launcher_launch! { launch1(

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,4 +1,3 @@
-use core::str;
 #[cfg(feature = "host")]
 use std::{
     ffi::{CStr, CString},
@@ -309,7 +308,7 @@ impl RawPtxKernel {
         // FIXME: cust's Module::get_function takes a str and turns it back into
         //        a CString immediately
         let function = unsafe { &*std::ptr::from_ref(module.as_ref()) }
-            .get_function(unsafe { str::from_utf8_unchecked(entry_point.to_bytes()) });
+            .get_function(unsafe { core::str::from_utf8_unchecked(entry_point.to_bytes()) });
 
         let function = match function {
             Ok(function) => function,

--- a/src/kernel/param.rs
+++ b/src/kernel/param.rs
@@ -88,7 +88,7 @@ impl<
     type SyncHostType = T;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         _stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -124,7 +124,7 @@ impl<
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         _token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -180,7 +180,7 @@ impl<
     type SyncHostType = &'a T;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -219,7 +219,7 @@ impl<
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         _token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -273,7 +273,7 @@ impl<
     type SyncHostType = <&'a PerThreadShallowCopy<T> as CudaKernelParameter>::SyncHostType;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -315,7 +315,7 @@ impl<
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -403,7 +403,7 @@ impl<
     type SyncHostType = &'a mut T;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -442,7 +442,7 @@ impl<
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         _token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -549,7 +549,7 @@ impl<
     type SyncHostType = T;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -585,7 +585,7 @@ impl<
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         _token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -644,7 +644,7 @@ impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a DeepPerThreadBorrow<T
     type SyncHostType = &'a T;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -683,7 +683,7 @@ impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a DeepPerThreadBorrow<T
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         _token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -737,7 +737,7 @@ impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
     type SyncHostType = &'a mut T;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -781,7 +781,7 @@ impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         mut param: Self::AsyncHostType<'stream, 'b>,
         _token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -835,7 +835,7 @@ impl<
     type SyncHostType = <DeepPerThreadBorrow<T> as CudaKernelParameter>::SyncHostType;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -862,7 +862,7 @@ impl<
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -926,7 +926,7 @@ impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a PtxJit<DeepPerThreadB
     type SyncHostType = <&'a DeepPerThreadBorrow<T> as CudaKernelParameter>::SyncHostType;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -968,7 +968,7 @@ impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a PtxJit<DeepPerThreadB
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -1017,7 +1017,7 @@ impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
     type SyncHostType = <&'a mut DeepPerThreadBorrow<T> as CudaKernelParameter>::SyncHostType;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -1064,7 +1064,7 @@ impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -1154,7 +1154,7 @@ impl<'a, T: 'static> CudaKernelParameter for &'a mut crate::utils::shared::Threa
     type SyncHostType = Self;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         _stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -1190,7 +1190,7 @@ impl<'a, T: 'static> CudaKernelParameter for &'a mut crate::utils::shared::Threa
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         _param: Self::AsyncHostType<'stream, 'b>,
         _token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>
@@ -1241,7 +1241,7 @@ impl<'a, T: 'static + PortableBitSemantics + TypeGraphLayout> CudaKernelParamete
     type SyncHostType = Self;
 
     #[cfg(feature = "host")]
-    fn with_new_async<'stream, 'b, O, E: From<rustacuda::error::CudaError>>(
+    fn with_new_async<'stream, 'b, O, E: From<cust::error::CudaError>>(
         param: Self::SyncHostType,
         _stream: crate::host::Stream<'stream>,
         #[cfg(not(doc))] inner: impl super::WithNewAsync<'stream, Self, O, E>,
@@ -1277,7 +1277,7 @@ impl<'a, T: 'static + PortableBitSemantics + TypeGraphLayout> CudaKernelParamete
     }
 
     #[cfg(feature = "host")]
-    fn async_to_ffi<'stream, 'b, E: From<rustacuda::error::CudaError>>(
+    fn async_to_ffi<'stream, 'b, E: From<cust::error::CudaError>>(
         param: Self::AsyncHostType<'stream, 'b>,
         _token: sealed::Token,
     ) -> Result<Self::FfiType<'stream, 'b>, E>

--- a/src/kernel/param.rs
+++ b/src/kernel/param.rs
@@ -157,7 +157,7 @@ impl<
 {
 }
 
-#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
+#[cfg_attr(not(feature = "host"), expect(clippy::needless_lifetimes))]
 impl<
         'a,
         T: Sync + crate::safety::StackOnly + crate::safety::PortableBitSemantics + TypeGraphLayout,
@@ -373,7 +373,7 @@ impl<
     }
 }
 
-#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
+#[cfg_attr(not(feature = "host"), expect(clippy::needless_lifetimes))]
 impl<
         'a,
         T: Sync
@@ -617,7 +617,7 @@ impl<
 {
 }
 
-#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
+#[cfg_attr(not(feature = "host"), expect(clippy::needless_lifetimes))]
 impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a DeepPerThreadBorrow<T> {
     #[cfg(feature = "host")]
     type AsyncHostType<'stream, 'b>
@@ -709,7 +709,7 @@ impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a DeepPerThreadBorrow<T
 }
 impl<T: Sync + RustToCuda> sealed::Sealed for &DeepPerThreadBorrow<T> {}
 
-#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
+#[cfg_attr(not(feature = "host"), expect(clippy::needless_lifetimes))]
 impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
     for &'a mut DeepPerThreadBorrow<T>
 {

--- a/src/kernel/param.rs
+++ b/src/kernel/param.rs
@@ -807,10 +807,7 @@ impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
         }
     }
 }
-impl<T: Sync + RustToCuda + SafeMutableAliasing> sealed::Sealed
-    for &mut DeepPerThreadBorrow<T>
-{
-}
+impl<T: Sync + RustToCuda + SafeMutableAliasing> sealed::Sealed for &mut DeepPerThreadBorrow<T> {}
 
 impl<
         T: Send

--- a/src/kernel/param.rs
+++ b/src/kernel/param.rs
@@ -157,6 +157,7 @@ impl<
 {
 }
 
+#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
 impl<
         'a,
         T: Sync + crate::safety::StackOnly + crate::safety::PortableBitSemantics + TypeGraphLayout,
@@ -244,9 +245,8 @@ impl<
     }
 }
 impl<
-        'a,
         T: Sync + crate::safety::StackOnly + crate::safety::PortableBitSemantics + TypeGraphLayout,
-    > sealed::Sealed for &'a PerThreadShallowCopy<T>
+    > sealed::Sealed for &PerThreadShallowCopy<T>
 {
 }
 
@@ -342,9 +342,8 @@ impl<
     }
 }
 impl<
-        'a,
         T: Sync + crate::safety::StackOnly + crate::safety::PortableBitSemantics + TypeGraphLayout,
-    > sealed::Sealed for &'a PtxJit<PerThreadShallowCopy<T>>
+    > sealed::Sealed for &PtxJit<PerThreadShallowCopy<T>>
 {
 }
 
@@ -374,6 +373,7 @@ impl<
     }
 }
 
+#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
 impl<
         'a,
         T: Sync
@@ -467,13 +467,12 @@ impl<
     }
 }
 impl<
-        'a,
         T: crate::safety::StackOnly
             + Sync
             + crate::safety::PortableBitSemantics
             + TypeGraphLayout
             + InteriorMutableSync,
-    > sealed::Sealed for &'a ShallowInteriorMutable<T>
+    > sealed::Sealed for &ShallowInteriorMutable<T>
 {
 }
 
@@ -618,6 +617,7 @@ impl<
 {
 }
 
+#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
 impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a DeepPerThreadBorrow<T> {
     #[cfg(feature = "host")]
     type AsyncHostType<'stream, 'b>
@@ -707,8 +707,9 @@ impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a DeepPerThreadBorrow<T
         }
     }
 }
-impl<'a, T: Sync + RustToCuda> sealed::Sealed for &'a DeepPerThreadBorrow<T> {}
+impl<T: Sync + RustToCuda> sealed::Sealed for &DeepPerThreadBorrow<T> {}
 
+#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
 impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
     for &'a mut DeepPerThreadBorrow<T>
 {
@@ -806,8 +807,8 @@ impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
         }
     }
 }
-impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> sealed::Sealed
-    for &'a mut DeepPerThreadBorrow<T>
+impl<T: Sync + RustToCuda + SafeMutableAliasing> sealed::Sealed
+    for &mut DeepPerThreadBorrow<T>
 {
 }
 
@@ -994,7 +995,7 @@ impl<'a, T: Sync + RustToCuda> CudaKernelParameter for &'a PtxJit<DeepPerThreadB
         }
     }
 }
-impl<'a, T: Sync + RustToCuda> sealed::Sealed for &'a PtxJit<DeepPerThreadBorrow<T>> {}
+impl<T: Sync + RustToCuda> sealed::Sealed for &PtxJit<DeepPerThreadBorrow<T>> {}
 
 impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
     for &'a mut PtxJit<DeepPerThreadBorrow<T>>
@@ -1090,8 +1091,8 @@ impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> CudaKernelParameter
         }
     }
 }
-impl<'a, T: Sync + RustToCuda + SafeMutableAliasing> sealed::Sealed
-    for &'a mut PtxJit<DeepPerThreadBorrow<T>>
+impl<T: Sync + RustToCuda + SafeMutableAliasing> sealed::Sealed
+    for &mut PtxJit<DeepPerThreadBorrow<T>>
 {
 }
 
@@ -1135,7 +1136,7 @@ mod private_shared {
     }
 }
 
-impl<'a, T: 'static> CudaKernelParameter for &'a mut crate::utils::shared::ThreadBlockShared<T> {
+impl<T: 'static> CudaKernelParameter for &mut crate::utils::shared::ThreadBlockShared<T> {
     #[cfg(feature = "host")]
     type AsyncHostType<'stream, 'b>
         = &'b mut crate::utils::shared::ThreadBlockShared<T>
@@ -1218,10 +1219,10 @@ impl<'a, T: 'static> CudaKernelParameter for &'a mut crate::utils::shared::Threa
         inner.with(&mut param)
     }
 }
-impl<'a, T: 'static> sealed::Sealed for &'a mut crate::utils::shared::ThreadBlockShared<T> {}
+impl<T: 'static> sealed::Sealed for &mut crate::utils::shared::ThreadBlockShared<T> {}
 
-impl<'a, T: 'static + PortableBitSemantics + TypeGraphLayout> CudaKernelParameter
-    for &'a mut crate::utils::shared::ThreadBlockSharedSlice<T>
+impl<T: 'static + PortableBitSemantics + TypeGraphLayout> CudaKernelParameter
+    for &mut crate::utils::shared::ThreadBlockSharedSlice<T>
 {
     #[cfg(feature = "host")]
     type AsyncHostType<'stream, 'b>
@@ -1307,7 +1308,7 @@ impl<'a, T: 'static + PortableBitSemantics + TypeGraphLayout> CudaKernelParamete
         }
     }
 }
-impl<'a, T: 'static + PortableBitSemantics + TypeGraphLayout> sealed::Sealed
-    for &'a mut crate::utils::shared::ThreadBlockSharedSlice<T>
+impl<T: 'static + PortableBitSemantics + TypeGraphLayout> sealed::Sealed
+    for &mut crate::utils::shared::ThreadBlockSharedSlice<T>
 {
 }

--- a/src/kernel/ptx_jit/regex.rs
+++ b/src/kernel/ptx_jit/regex.rs
@@ -2,7 +2,6 @@ use std::sync::OnceLock;
 
 use regex::bytes::Regex;
 
-#[expect(clippy::module_name_repetitions)]
 pub fn const_marker_regex() -> &'static Regex {
     static CONST_MARKER_REGEX: OnceLock<Regex> = OnceLock::new();
     #[allow(clippy::unwrap_used)]
@@ -12,7 +11,6 @@ pub fn const_marker_regex() -> &'static Regex {
     })
 }
 
-#[expect(clippy::module_name_repetitions)]
 pub fn const_base_register_regex() -> &'static Regex {
     static CONST_BASE_REGISTER_REGEX: OnceLock<Regex> = OnceLock::new();
     #[allow(clippy::unwrap_used)]
@@ -22,7 +20,6 @@ pub fn const_base_register_regex() -> &'static Regex {
     })
 }
 
-#[expect(clippy::module_name_repetitions)]
 pub fn const_load_instruction_regex() -> &'static Regex {
     static CONST_LOAD_INSTRUCTION_REGEX: OnceLock<Regex> = OnceLock::new();
     #[allow(clippy::unwrap_used)]
@@ -54,7 +51,6 @@ pub fn const_load_instruction_regex() -> &'static Regex {
     })
 }
 
-#[expect(clippy::module_name_repetitions)]
 pub fn register_regex() -> &'static Regex {
     static REGISTER_REGEX: OnceLock<Regex> = OnceLock::new();
     #[allow(clippy::unwrap_used)]

--- a/src/lend/impls/arc.rs
+++ b/src/lend/impls/arc.rs
@@ -107,6 +107,7 @@ unsafe impl<T: PortableBitSemantics + TypeGraphLayout> RustToCudaAsync for Arc<T
         use cust::memory::AsyncCopyDestination;
 
         let locked_box = unsafe {
+            #[allow(clippy::used_underscore_items)]
             let inner = ManuallyDrop::new(_ArcInner {
                 strong: AtomicUsize::new(1),
                 weak: AtomicUsize::new(1),

--- a/src/lend/impls/arc.rs
+++ b/src/lend/impls/arc.rs
@@ -30,7 +30,6 @@ use crate::{
 #[doc(hidden)]
 #[repr(transparent)]
 #[derive(TypeLayout)]
-#[expect(clippy::module_name_repetitions)]
 pub struct ArcCudaRepresentation<T: PortableBitSemantics + TypeGraphLayout>(
     DeviceOwnedPointer<_ArcInner<T>>,
 );

--- a/src/lend/impls/arced_slice.rs
+++ b/src/lend/impls/arced_slice.rs
@@ -33,7 +33,6 @@ use crate::{
 };
 
 #[doc(hidden)]
-#[expect(clippy::module_name_repetitions)]
 #[derive(TypeLayout)]
 #[repr(C)]
 pub struct ArcedSliceCudaRepresentation<T: PortableBitSemantics + TypeGraphLayout> {
@@ -81,31 +80,32 @@ unsafe impl<T: PortableBitSemantics + TypeGraphLayout> RustToCuda for Arc<[T]> {
         DeviceAccessible<Self::CudaRepresentation>,
         CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
-        use cust::memory::{CopyDestination, DevicePointer, DeviceSlice};
+        use cust::memory::{CopyDestination, DeviceSlice};
 
         let data_ptr: *const T = std::ptr::from_ref(&**self).as_ptr();
         let offset = std::mem::offset_of!(_ArcInner<[T; 42]>, data);
         let arc_ptr: *const _ArcInner<[T; 42]> = data_ptr.byte_sub(offset).cast();
 
-        let header_len = (offset + (std::mem::align_of::<T>() - 1)) / std::mem::align_of::<T>();
+        let header_len = offset.div_ceil(std::mem::align_of::<T>());
 
-        let mut device_buffer = CudaDropWrapper::from(DeviceBuffer::<
+        let device_buffer = CudaDropWrapper::from(DeviceBuffer::<
             DeviceCopyWithPortableBitSemantics<T>,
         >::uninitialized(
             header_len + self.len()
         )?);
-        let (header, buffer): (&mut DeviceSlice<_>, &mut DeviceSlice<_>) =
-            device_buffer.split_at_mut(header_len);
+
+        let mut buffer: DeviceSlice<_> = device_buffer.index(header_len..);
         buffer.copy_from(std::slice::from_raw_parts(self.as_ptr().cast(), self.len()))?;
+
+        let header: DeviceSlice<_> = device_buffer.index(..header_len);
         let header = DeviceSlice::from_raw_parts_mut(
-            DevicePointer::wrap(header.as_mut_ptr().cast::<u8>()),
+            header.as_device_ptr().cast::<u8>(),
             header.len() * std::mem::size_of::<T>(),
         );
-        let (_, header) = header.split_at_mut(header.len() - offset);
-        let (header, _) = header.split_at_mut(std::mem::size_of::<_ArcInnerHeader>());
-        #[expect(clippy::cast_ptr_alignment)]
+        let header = header.index((header.len() - offset)..);
+        let header = header.index(..std::mem::size_of::<_ArcInnerHeader>());
         let mut header: ManuallyDrop<DeviceBox<_ArcInnerHeader>> = ManuallyDrop::new(
-            DeviceBox::from_raw(header.as_mut_ptr().cast::<_ArcInnerHeader>()),
+            DeviceBox::from_device(header.as_device_ptr().cast::<_ArcInnerHeader>()),
         );
         header.copy_from(&*arc_ptr.cast::<_ArcInnerHeader>())?;
 
@@ -152,7 +152,7 @@ unsafe impl<T: PortableBitSemantics + TypeGraphLayout> RustToCudaAsync for Arc<[
         let offset = std::mem::offset_of!(_ArcInner<[T; 42]>, data);
         let arc_ptr: *const _ArcInner<[T; 42]> = data_ptr.byte_sub(offset).cast();
 
-        let header_len = (offset + (std::mem::align_of::<T>() - 1)) / std::mem::align_of::<T>();
+        let header_len = offset.div_ceil(std::mem::align_of::<T>());
 
         let locked_buffer = unsafe {
             let mut locked_buffer =

--- a/src/lend/impls/arced_slice.rs
+++ b/src/lend/impls/arced_slice.rs
@@ -8,9 +8,8 @@ use const_type_layout::{TypeGraphLayout, TypeLayout};
 use cust::{
     error::CudaResult,
     memory::LockedBuffer,
-    memory::{DeviceBox, DeviceBuffer},
+    memory::{DeviceBox, DeviceBuffer, DeviceCopy},
 };
-use cust_core::DeviceCopy;
 
 use crate::{
     deps::alloc::sync::Arc,
@@ -50,20 +49,20 @@ pub struct _ArcInner<T: ?Sized> {
     data: T,
 }
 
-#[derive(Copy, Clone)]
+#[cfg(feature = "host")]
+#[derive(Copy, Clone, DeviceCopy)]
 #[repr(C)]
 struct _ArcInnerHeader {
     strong: _AtomicUsize,
     weak: _AtomicUsize,
 }
 
-#[derive(Copy, Clone)]
+#[cfg(feature = "host")]
+#[derive(Copy, Clone, DeviceCopy)]
 #[repr(C, align(8))]
 struct _AtomicUsize {
     v: usize,
 }
-
-unsafe impl DeviceCopy for _ArcInnerHeader {}
 
 unsafe impl<T: PortableBitSemantics + TypeGraphLayout> RustToCuda for Arc<[T]> {
     #[cfg(all(feature = "host", not(doc)))]

--- a/src/lend/impls/box.rs
+++ b/src/lend/impls/box.rs
@@ -29,7 +29,6 @@ use crate::{
 #[doc(hidden)]
 #[repr(transparent)]
 #[derive(TypeLayout)]
-#[expect(clippy::module_name_repetitions)]
 pub struct BoxCudaRepresentation<T: PortableBitSemantics + TypeGraphLayout>(DeviceOwnedPointer<T>);
 
 unsafe impl<T: PortableBitSemantics + TypeGraphLayout> RustToCuda for Box<T> {

--- a/src/lend/impls/boxed_slice.rs
+++ b/src/lend/impls/boxed_slice.rs
@@ -26,7 +26,6 @@ use crate::{
 };
 
 #[doc(hidden)]
-#[expect(clippy::module_name_repetitions)]
 #[derive(TypeLayout)]
 #[repr(C)]
 pub struct BoxedSliceCudaRepresentation<T: PortableBitSemantics + TypeGraphLayout> {

--- a/src/lend/impls/final.rs
+++ b/src/lend/impls/final.rs
@@ -19,7 +19,7 @@ unsafe impl<T: RustToCuda> RustToCuda for Final<T> {
     unsafe fn borrow<A: crate::alloc::CudaAlloc>(
         &self,
         alloc: A,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         DeviceAccessible<Self::CudaRepresentation>,
         crate::alloc::CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
@@ -35,7 +35,7 @@ unsafe impl<T: RustToCuda> RustToCuda for Final<T> {
     unsafe fn restore<A: crate::alloc::CudaAlloc>(
         &mut self,
         alloc: crate::alloc::CombinedCudaAlloc<Self::CudaAllocation, A>,
-    ) -> rustacuda::error::CudaResult<A> {
+    ) -> cust::error::CudaResult<A> {
         let (_alloc_front, alloc_tail) = alloc.split();
         Ok(alloc_tail)
     }
@@ -49,7 +49,7 @@ unsafe impl<T: RustToCudaAsync> RustToCudaAsync for Final<T> {
         &self,
         alloc: A,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<'_, 'stream, DeviceAccessible<Self::CudaRepresentation>>,
         crate::alloc::CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
     )> {
@@ -76,7 +76,7 @@ unsafe impl<T: RustToCudaAsync> RustToCudaAsync for Final<T> {
         this: owning_ref::BoxRefMut<'a, O, Self>,
         alloc: crate::alloc::CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<
             'a,
             'stream,

--- a/src/lend/impls/final.rs
+++ b/src/lend/impls/final.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 
 #[doc(hidden)]
-#[expect(clippy::module_name_repetitions)]
 #[derive(const_type_layout::TypeLayout)]
 #[repr(transparent)]
 pub struct FinalCudaRepresentation<T: CudaAsRust>(DeviceAccessible<T>);

--- a/src/lend/impls/mod.rs
+++ b/src/lend/impls/mod.rs
@@ -1,5 +1,5 @@
 mod arc;
-mod arced_slice;
+// mod arced_slice;
 mod r#box;
 mod boxed_slice;
 #[cfg(feature = "final")]

--- a/src/lend/impls/mod.rs
+++ b/src/lend/impls/mod.rs
@@ -1,5 +1,5 @@
 mod arc;
-// mod arced_slice;
+mod arced_slice;
 mod r#box;
 mod boxed_slice;
 #[cfg(feature = "final")]

--- a/src/lend/impls/option.rs
+++ b/src/lend/impls/option.rs
@@ -3,7 +3,7 @@ use core::mem::MaybeUninit;
 use const_type_layout::{TypeGraphLayout, TypeLayout};
 
 #[cfg(feature = "host")]
-use rustacuda::error::CudaResult;
+use cust::error::CudaResult;
 
 use crate::{
     lend::{CudaAsRust, RustToCuda, RustToCudaAsync, RustToCudaProxy},

--- a/src/lend/impls/option.rs
+++ b/src/lend/impls/option.rs
@@ -18,7 +18,6 @@ use crate::{
 };
 
 #[doc(hidden)]
-#[expect(clippy::module_name_repetitions)]
 #[derive(TypeLayout)]
 #[repr(C)]
 pub struct OptionCudaRepresentation<T: CudaAsRust> {

--- a/src/lend/impls/ref.rs
+++ b/src/lend/impls/ref.rs
@@ -71,7 +71,7 @@ unsafe impl<'a, T: PortableBitSemantics + TypeGraphLayout> RustToCuda for &'a T 
     }
 }
 
-unsafe impl<'a, T: PortableBitSemantics + TypeGraphLayout> RustToCudaAsync for &'a T {
+unsafe impl<T: PortableBitSemantics + TypeGraphLayout> RustToCudaAsync for &T {
     #[cfg(all(feature = "host", not(doc)))]
     type CudaAllocationAsync = CombinedCudaAlloc<
         CudaDropWrapper<LockedBox<DeviceCopyWithPortableBitSemantics<ManuallyDrop<T>>>>,

--- a/src/lend/impls/ref.rs
+++ b/src/lend/impls/ref.rs
@@ -27,7 +27,6 @@ use crate::{
 #[doc(hidden)]
 #[repr(transparent)]
 #[derive(TypeLayout)]
-#[expect(clippy::module_name_repetitions)]
 pub struct RefCudaRepresentation<'a, T: 'a + PortableBitSemantics + TypeGraphLayout> {
     data: DeviceConstPointer<T>,
     _marker: PhantomData<&'a T>,

--- a/src/lend/impls/ref_mut.rs
+++ b/src/lend/impls/ref_mut.rs
@@ -24,7 +24,6 @@ use crate::{
 #[doc(hidden)]
 #[repr(transparent)]
 #[derive(TypeLayout)]
-#[expect(clippy::module_name_repetitions)]
 pub struct RefMutCudaRepresentation<'a, T: 'a + PortableBitSemantics + TypeGraphLayout> {
     data: DeviceMutPointer<T>,
     _marker: PhantomData<&'a mut T>,

--- a/src/lend/impls/slice_ref.rs
+++ b/src/lend/impls/slice_ref.rs
@@ -25,7 +25,6 @@ use crate::{
 };
 
 #[doc(hidden)]
-#[expect(clippy::module_name_repetitions)]
 #[derive(TypeLayout)]
 #[repr(C)]
 pub struct SliceRefCudaRepresentation<'a, T: 'a + PortableBitSemantics + TypeGraphLayout> {

--- a/src/lend/impls/slice_ref.rs
+++ b/src/lend/impls/slice_ref.rs
@@ -74,6 +74,7 @@ unsafe impl<'a, T: PortableBitSemantics + TypeGraphLayout> RustToCuda for &'a [T
     }
 }
 
+#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
 unsafe impl<'a, T: PortableBitSemantics + TypeGraphLayout> RustToCudaAsync for &'a [T] {
     #[cfg(all(feature = "host", not(doc)))]
     type CudaAllocationAsync = CombinedCudaAlloc<

--- a/src/lend/impls/slice_ref.rs
+++ b/src/lend/impls/slice_ref.rs
@@ -73,7 +73,7 @@ unsafe impl<'a, T: PortableBitSemantics + TypeGraphLayout> RustToCuda for &'a [T
     }
 }
 
-#[cfg_attr(feature = "device", expect(clippy::needless_lifetimes))]
+#[cfg_attr(not(feature = "host"), expect(clippy::needless_lifetimes))]
 unsafe impl<'a, T: PortableBitSemantics + TypeGraphLayout> RustToCudaAsync for &'a [T] {
     #[cfg(all(feature = "host", not(doc)))]
     type CudaAllocationAsync = CombinedCudaAlloc<

--- a/src/lend/impls/slice_ref_mut.rs
+++ b/src/lend/impls/slice_ref_mut.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 
 #[doc(hidden)]
-#[expect(clippy::module_name_repetitions)]
 #[derive(TypeLayout)]
 #[repr(C)]
 pub struct SliceRefMutCudaRepresentation<'a, T: 'a + PortableBitSemantics + TypeGraphLayout> {

--- a/src/lend/mod.rs
+++ b/src/lend/mod.rs
@@ -1,6 +1,6 @@
 use const_type_layout::TypeGraphLayout;
 #[cfg(feature = "host")]
-use rustacuda::error::CudaError;
+use cust::error::CudaError;
 
 #[cfg(feature = "derive")]
 #[expect(clippy::module_name_repetitions)]
@@ -34,7 +34,7 @@ pub unsafe trait RustToCuda {
     #[cfg(feature = "host")]
     /// # Errors
     ///
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA
     ///
     /// # Safety
@@ -46,7 +46,7 @@ pub unsafe trait RustToCuda {
     unsafe fn borrow<A: CudaAlloc>(
         &self,
         alloc: A,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         DeviceAccessible<Self::CudaRepresentation>,
         CombinedCudaAlloc<Self::CudaAllocation, A>,
     )>;
@@ -55,7 +55,7 @@ pub unsafe trait RustToCuda {
     #[cfg(feature = "host")]
     /// # Errors
     ///
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA
     ///
     /// # Safety
@@ -64,7 +64,7 @@ pub unsafe trait RustToCuda {
     unsafe fn restore<A: CudaAlloc>(
         &mut self,
         alloc: CombinedCudaAlloc<Self::CudaAllocation, A>,
-    ) -> rustacuda::error::CudaResult<A>;
+    ) -> cust::error::CudaResult<A>;
 }
 
 /// # Safety
@@ -78,7 +78,7 @@ pub unsafe trait RustToCudaAsync: RustToCuda {
     #[cfg(feature = "host")]
     /// # Errors
     ///
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA
     ///
     /// # Safety
@@ -101,7 +101,7 @@ pub unsafe trait RustToCudaAsync: RustToCuda {
         &self,
         alloc: A,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         Async<'_, 'stream, DeviceAccessible<Self::CudaRepresentation>>,
         CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
     )>;
@@ -110,7 +110,7 @@ pub unsafe trait RustToCudaAsync: RustToCuda {
     #[cfg(feature = "host")]
     /// # Errors
     ///
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA
     ///
     /// # Safety
@@ -127,7 +127,7 @@ pub unsafe trait RustToCudaAsync: RustToCuda {
         this: owning_ref::BoxRefMut<'a, O, Self>,
         alloc: CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         Async<'a, 'stream, owning_ref::BoxRefMut<'a, O, Self>, CompletionFnMut<'a, Self>>,
         A,
     )>;
@@ -187,7 +187,7 @@ pub trait LendToCuda: RustToCuda {
     ///
     /// # Errors
     ///
-    /// Returns a `rustacuda::errors::CudaError` iff an error occurs inside CUDA
+    /// Returns a `cust::errors::CudaError` iff an error occurs inside CUDA
     fn lend_to_cuda_mut<
         O,
         E: From<CudaError>,
@@ -339,7 +339,7 @@ pub trait LendToCudaAsync: RustToCudaAsync {
     ///
     /// # Errors
     ///
-    /// Returns a `rustacuda::errors::CudaError` iff an error occurs inside CUDA
+    /// Returns a `cust::errors::CudaError` iff an error occurs inside CUDA
     fn lend_to_cuda_mut_async<
         'a,
         'stream,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! [CI Status]: https://img.shields.io/github/actions/workflow/status/juntyr/rust-cuda/ci.yml?branch=main
 //! [workflow]: https://github.com/juntyr/rust-cuda/actions/workflows/ci.yml?query=branch%3Amain
 //!
-//! [MSRV]: https://img.shields.io/badge/MSRV-1.81.0--nightly-orange
+//! [MSRV]: https://img.shields.io/badge/MSRV-1.84.0--nightly-orange
 //! [repo]: https://github.com/juntyr/rust-cuda
 //!
 //! [Rust Doc]: https://img.shields.io/badge/docs-main-blue

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 #![feature(negative_impls)]
 #![cfg_attr(all(feature = "device", not(doc)), feature(stdarch_nvptx))]
 #![cfg_attr(feature = "device", feature(asm_experimental_arch))]
-#![cfg_attr(feature = "device", feature(asm_const))]
 #![feature(doc_auto_cfg)]
 #![feature(doc_cfg)]
 #![feature(marker_trait_attr)]
@@ -48,7 +47,6 @@
 #![feature(generic_const_exprs)]
 #![expect(internal_features)]
 #![feature(core_intrinsics)]
-// #![feature(const_intrinsic_compare_bytes)]
 #![doc(html_root_url = "https://juntyr.github.io/rust-cuda/")]
 
 #[cfg(all(feature = "host", feature = "device", not(doc)))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 #![feature(generic_const_exprs)]
 #![expect(internal_features)]
 #![feature(core_intrinsics)]
-#![feature(const_intrinsic_compare_bytes)]
+// #![feature(const_intrinsic_compare_bytes)]
 #![doc(html_root_url = "https://juntyr.github.io/rust-cuda/")]
 
 #[cfg(all(feature = "host", feature = "device", not(doc)))]

--- a/src/safety/aliasing.rs
+++ b/src/safety/aliasing.rs
@@ -38,23 +38,21 @@
 pub unsafe trait SafeMutableAliasing {}
 
 unsafe impl<
-        'a,
         T: crate::safety::StackOnly
             + crate::safety::PortableBitSemantics
             + const_type_layout::TypeGraphLayout,
         const STRIDE: usize,
     > SafeMutableAliasing
-    for crate::utils::aliasing::SplitSliceOverCudaThreadsConstStride<&'a mut [T], STRIDE>
+    for crate::utils::aliasing::SplitSliceOverCudaThreadsConstStride<&mut [T], STRIDE>
 {
 }
 
 unsafe impl<
-        'a,
         T: crate::safety::StackOnly
             + crate::safety::PortableBitSemantics
             + const_type_layout::TypeGraphLayout,
     > SafeMutableAliasing
-    for crate::utils::aliasing::SplitSliceOverCudaThreadsDynamicStride<&'a mut [T]>
+    for crate::utils::aliasing::SplitSliceOverCudaThreadsDynamicStride<&mut [T]>
 {
 }
 

--- a/src/safety/aliasing.rs
+++ b/src/safety/aliasing.rs
@@ -1,4 +1,3 @@
-#[expect(clippy::module_name_repetitions)]
 /// Types for which mutable references can be safely shared with each CUDA
 /// thread without breaking Rust's no-mutable-aliasing memory safety
 /// guarantees.

--- a/src/safety/portable.rs
+++ b/src/safety/portable.rs
@@ -36,7 +36,6 @@ macro_rules! portable_bit_semantics_docs {
 
 #[cfg(not(doc))]
 portable_bit_semantics_docs! {
-    #[expect(clippy::module_name_repetitions)]
     pub trait PortableBitSemantics: sealed::PortableBitSemantics {}
 }
 #[cfg(doc)]

--- a/src/safety/portable.rs
+++ b/src/safety/portable.rs
@@ -1,8 +1,11 @@
 macro_rules! portable_bit_semantics_docs {
     ($item:item) => {
-        /// Types whose in-memory bit representation on the CPU host is safe to copy
-        /// to and read back on the GPU device while maintaining the same semantics,
-        /// iff the type layout on the CPU matches the type layout on the GPU.
+        /// Types with a CPU-GPU-compatible memory representation.
+        ///
+        /// More specifically, types in-memory bit representation on the CPU host
+        /// is safe to copy to and read back on the GPU device while maintaining
+        /// the same semantics, iff the type layout on the CPU matches the type
+        /// layout on the GPU.
         ///
         /// For a type to implement [`PortableBitSemantics`], it
         ///

--- a/src/utils/adapter.rs
+++ b/src/utils/adapter.rs
@@ -124,7 +124,7 @@ unsafe impl<T: Copy + PortableBitSemantics + TypeGraphLayout> RustToCuda
     unsafe fn borrow<A: CudaAlloc>(
         &self,
         alloc: A,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         DeviceAccessible<Self::CudaRepresentation>,
         CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
@@ -136,7 +136,7 @@ unsafe impl<T: Copy + PortableBitSemantics + TypeGraphLayout> RustToCuda
     unsafe fn restore<A: CudaAlloc>(
         &mut self,
         alloc: CombinedCudaAlloc<Self::CudaAllocation, A>,
-    ) -> rustacuda::error::CudaResult<A> {
+    ) -> cust::error::CudaResult<A> {
         let (_alloc_front, alloc_tail): (NoCudaAlloc, A) = alloc.split();
 
         Ok(alloc_tail)
@@ -153,7 +153,7 @@ unsafe impl<T: Copy + PortableBitSemantics + TypeGraphLayout> RustToCudaAsync
         &self,
         alloc: A,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<'_, 'stream, DeviceAccessible<Self::CudaRepresentation>>,
         CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
@@ -169,7 +169,7 @@ unsafe impl<T: Copy + PortableBitSemantics + TypeGraphLayout> RustToCudaAsync
         this: owning_ref::BoxRefMut<'a, O, Self>,
         alloc: CombinedCudaAlloc<Self::CudaAllocation, A>,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<
             'a,
             'stream,
@@ -312,7 +312,7 @@ unsafe impl<T: Clone + PortableBitSemantics + TypeGraphLayout> RustToCuda
     unsafe fn borrow<A: CudaAlloc>(
         &self,
         alloc: A,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         DeviceAccessible<Self::CudaRepresentation>,
         CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
@@ -324,7 +324,7 @@ unsafe impl<T: Clone + PortableBitSemantics + TypeGraphLayout> RustToCuda
     unsafe fn restore<A: CudaAlloc>(
         &mut self,
         alloc: CombinedCudaAlloc<Self::CudaAllocation, A>,
-    ) -> rustacuda::error::CudaResult<A> {
+    ) -> cust::error::CudaResult<A> {
         let (_alloc_front, alloc_tail): (NoCudaAlloc, A) = alloc.split();
 
         Ok(alloc_tail)
@@ -341,7 +341,7 @@ unsafe impl<T: Clone + PortableBitSemantics + TypeGraphLayout> RustToCudaAsync
         &self,
         alloc: A,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<'_, 'stream, DeviceAccessible<Self::CudaRepresentation>>,
         CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
@@ -357,7 +357,7 @@ unsafe impl<T: Clone + PortableBitSemantics + TypeGraphLayout> RustToCudaAsync
         this: owning_ref::BoxRefMut<'a, O, Self>,
         alloc: CombinedCudaAlloc<Self::CudaAllocation, A>,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<
             'a,
             'stream,
@@ -394,7 +394,7 @@ unsafe impl<T: Clone + PortableBitSemantics + TypeGraphLayout> CudaAsRust
 #[repr(transparent)]
 pub struct DeviceCopyWithPortableBitSemantics<T: PortableBitSemantics + TypeGraphLayout>(T);
 
-unsafe impl<T: PortableBitSemantics + TypeGraphLayout> rustacuda_core::DeviceCopy
+unsafe impl<T: PortableBitSemantics + TypeGraphLayout> cust_core::DeviceCopy
     for DeviceCopyWithPortableBitSemantics<T>
 {
 }

--- a/src/utils/aliasing/const.rs
+++ b/src/utils/aliasing/const.rs
@@ -193,7 +193,7 @@ unsafe impl<T: RustToCuda, const STRIDE: usize> RustToCuda
     unsafe fn borrow<A: crate::alloc::CudaAlloc>(
         &self,
         alloc: A,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         DeviceAccessible<Self::CudaRepresentation>,
         crate::alloc::CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
@@ -209,7 +209,7 @@ unsafe impl<T: RustToCuda, const STRIDE: usize> RustToCuda
     unsafe fn restore<A: crate::alloc::CudaAlloc>(
         &mut self,
         alloc: crate::alloc::CombinedCudaAlloc<Self::CudaAllocation, A>,
-    ) -> rustacuda::error::CudaResult<A> {
+    ) -> cust::error::CudaResult<A> {
         self.0.restore(alloc)
     }
 }
@@ -224,7 +224,7 @@ unsafe impl<T: RustToCudaAsync, const STRIDE: usize> RustToCudaAsync
         &self,
         alloc: A,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<'_, 'stream, DeviceAccessible<Self::CudaRepresentation>>,
         crate::alloc::CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
     )> {
@@ -252,7 +252,7 @@ unsafe impl<T: RustToCudaAsync, const STRIDE: usize> RustToCudaAsync
         this: owning_ref::BoxRefMut<'a, O, Self>,
         alloc: crate::alloc::CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<
             'a,
             'stream,

--- a/src/utils/aliasing/dynamic.rs
+++ b/src/utils/aliasing/dynamic.rs
@@ -170,7 +170,7 @@ unsafe impl<T: RustToCuda> RustToCuda for SplitSliceOverCudaThreadsDynamicStride
     unsafe fn borrow<A: crate::alloc::CudaAlloc>(
         &self,
         alloc: A,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         DeviceAccessible<Self::CudaRepresentation>,
         crate::alloc::CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
@@ -189,7 +189,7 @@ unsafe impl<T: RustToCuda> RustToCuda for SplitSliceOverCudaThreadsDynamicStride
     unsafe fn restore<A: crate::alloc::CudaAlloc>(
         &mut self,
         alloc: crate::alloc::CombinedCudaAlloc<Self::CudaAllocation, A>,
-    ) -> rustacuda::error::CudaResult<A> {
+    ) -> cust::error::CudaResult<A> {
         self.inner.restore(alloc)
     }
 }
@@ -202,7 +202,7 @@ unsafe impl<T: RustToCudaAsync> RustToCudaAsync for SplitSliceOverCudaThreadsDyn
         &self,
         alloc: A,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<'_, 'stream, DeviceAccessible<Self::CudaRepresentation>>,
         crate::alloc::CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
     )> {
@@ -232,7 +232,7 @@ unsafe impl<T: RustToCudaAsync> RustToCudaAsync for SplitSliceOverCudaThreadsDyn
         this: owning_ref::BoxRefMut<'a, O, Self>,
         alloc: crate::alloc::CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         crate::utils::r#async::Async<
             'a,
             'stream,

--- a/src/utils/async.rs
+++ b/src/utils/async.rs
@@ -2,7 +2,7 @@
 use std::{borrow::BorrowMut, future::Future, future::IntoFuture, marker::PhantomData, task::Poll};
 
 #[cfg(feature = "host")]
-use rustacuda::{
+use cust::{
     error::CudaError, error::CudaResult, event::Event, event::EventFlags,
     stream::StreamWaitEventFlags,
 };
@@ -136,7 +136,7 @@ impl<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> Async<'a, 'strea
     /// such that its computation can be synchronised on.
     ///
     /// # Errors
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA.
     pub fn pending(value: T, stream: Stream<'stream>, completion: C) -> CudaResult<Self> {
         let (sender, receiver) = oneshot::channel();
@@ -160,11 +160,11 @@ impl<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> Async<'a, 'strea
     /// operations.
     ///
     /// Calling `synchronize` after the computation has completed, e.g. after
-    /// calling [`rustacuda::stream::Stream::synchronize`], should be very
+    /// calling [`cust::stream::Stream::synchronize`], should be very
     /// cheap.
     ///
     /// # Errors
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA.
     pub fn synchronize(self) -> CudaResult<T> {
         let (_stream, mut value, status) = self.destructure_into_parts();
@@ -198,7 +198,7 @@ impl<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> Async<'a, 'strea
     /// used on the new one.
     ///
     /// # Errors
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA.
     pub fn move_to_stream<'stream_new>(
         self,

--- a/src/utils/async.rs
+++ b/src/utils/async.rs
@@ -434,9 +434,7 @@ struct AsyncFuture<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> {
 }
 
 #[cfg(feature = "host")]
-impl<T: BorrowMut<C::Completed>, C: Completion<T>> Future
-    for AsyncFuture<'_, '_, T, C>
-{
+impl<T: BorrowMut<C::Completed>, C: Completion<T>> Future for AsyncFuture<'_, '_, T, C> {
     type Output = CudaResult<T>;
 
     fn poll(
@@ -517,9 +515,7 @@ impl<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> IntoFuture
 }
 
 #[cfg(feature = "host")]
-impl<T: BorrowMut<C::Completed>, C: Completion<T>> Drop
-    for AsyncFuture<'_, '_, T, C>
-{
+impl<T: BorrowMut<C::Completed>, C: Completion<T>> Drop for AsyncFuture<'_, '_, T, C> {
     fn drop(&mut self) {
         let Some(mut value) = self.value.take() else {
             return;

--- a/src/utils/async.rs
+++ b/src/utils/async.rs
@@ -55,7 +55,7 @@ impl<T: ?Sized> Completion<T> for NoCompletion {
 impl sealed::Sealed for NoCompletion {}
 
 #[cfg(feature = "host")]
-impl<'a, T: ?Sized + BorrowMut<B>, B: ?Sized> Completion<T> for CompletionFnMut<'a, B> {
+impl<T: ?Sized + BorrowMut<B>, B: ?Sized> Completion<T> for CompletionFnMut<'_, B> {
     type Completed = B;
 
     #[inline]
@@ -74,7 +74,7 @@ impl<'a, T: ?Sized + BorrowMut<B>, B: ?Sized> Completion<T> for CompletionFnMut<
     }
 }
 #[cfg(feature = "host")]
-impl<'a, T: ?Sized> sealed::Sealed for CompletionFnMut<'a, T> {}
+impl<T: ?Sized> sealed::Sealed for CompletionFnMut<'_, T> {}
 
 #[cfg(feature = "host")]
 impl<T: ?Sized + BorrowMut<C::Completed>, C: Completion<T>> Completion<T> for Option<C> {
@@ -87,7 +87,7 @@ impl<T: ?Sized + BorrowMut<C::Completed>, C: Completion<T>> Completion<T> for Op
 
     #[inline]
     fn synchronize_on_drop(&self) -> bool {
-        self.as_ref().map_or(false, Completion::synchronize_on_drop)
+        self.as_ref().is_some_and(Completion::synchronize_on_drop)
     }
 
     #[inline]
@@ -407,7 +407,7 @@ where
 }
 
 #[cfg(feature = "host")]
-impl<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> Drop for Async<'a, 'stream, T, C> {
+impl<T: BorrowMut<C::Completed>, C: Completion<T>> Drop for Async<'_, '_, T, C> {
     fn drop(&mut self) {
         let AsyncStatus::Processing {
             receiver,
@@ -434,8 +434,8 @@ struct AsyncFuture<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> {
 }
 
 #[cfg(feature = "host")]
-impl<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> Future
-    for AsyncFuture<'a, 'stream, T, C>
+impl<T: BorrowMut<C::Completed>, C: Completion<T>> Future
+    for AsyncFuture<'_, '_, T, C>
 {
     type Output = CudaResult<T>;
 
@@ -517,8 +517,8 @@ impl<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> IntoFuture
 }
 
 #[cfg(feature = "host")]
-impl<'a, 'stream, T: BorrowMut<C::Completed>, C: Completion<T>> Drop
-    for AsyncFuture<'a, 'stream, T, C>
+impl<T: BorrowMut<C::Completed>, C: Completion<T>> Drop
+    for AsyncFuture<'_, '_, T, C>
 {
     fn drop(&mut self) {
         let Some(mut value) = self.value.take() else {

--- a/src/utils/exchange/buffer/device.rs
+++ b/src/utils/exchange/buffer/device.rs
@@ -9,7 +9,6 @@ use crate::{
 
 use super::CudaExchangeItem;
 
-#[expect(clippy::module_name_repetitions)]
 pub struct CudaExchangeBufferDevice<
     T: StackOnly + PortableBitSemantics + TypeGraphLayout,
     const M2D: bool,

--- a/src/utils/exchange/buffer/host.rs
+++ b/src/utils/exchange/buffer/host.rs
@@ -22,7 +22,6 @@ use crate::{
 
 use super::{common::CudaExchangeBufferCudaRepresentation, CudaExchangeItem};
 
-#[expect(clippy::module_name_repetitions)]
 pub struct CudaExchangeBufferHost<
     T: StackOnly + PortableBitSemantics + TypeGraphLayout,
     const M2D: bool,

--- a/src/utils/exchange/buffer/mod.rs
+++ b/src/utils/exchange/buffer/mod.rs
@@ -63,9 +63,9 @@ impl<
     > CudaExchangeBuffer<T, M2D, M2H>
 {
     /// # Errors
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA
-    pub fn new(elem: &T, capacity: usize) -> rustacuda::error::CudaResult<Self> {
+    pub fn new(elem: &T, capacity: usize) -> cust::error::CudaResult<Self> {
         Ok(Self {
             inner: host::CudaExchangeBufferHost::new(elem, capacity)?,
         })
@@ -77,9 +77,9 @@ impl<T: StackOnly + PortableBitSemantics + TypeGraphLayout, const M2D: bool, con
     CudaExchangeBuffer<T, M2D, M2H>
 {
     /// # Errors
-    /// Returns a [`rustacuda::error::CudaError`] iff an error occurs inside
+    /// Returns a [`cust::error::CudaError`] iff an error occurs inside
     /// CUDA
-    pub fn from_vec(vec: Vec<T>) -> rustacuda::error::CudaResult<Self> {
+    pub fn from_vec(vec: Vec<T>) -> cust::error::CudaResult<Self> {
         Ok(Self {
             inner: host::CudaExchangeBufferHost::from_vec(vec)?,
         })
@@ -117,7 +117,7 @@ unsafe impl<T: StackOnly + PortableBitSemantics + TypeGraphLayout, const M2D: bo
     unsafe fn borrow<A: CudaAlloc>(
         &self,
         alloc: A,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         DeviceAccessible<Self::CudaRepresentation>,
         CombinedCudaAlloc<Self::CudaAllocation, A>,
     )> {
@@ -128,7 +128,7 @@ unsafe impl<T: StackOnly + PortableBitSemantics + TypeGraphLayout, const M2D: bo
     unsafe fn restore<A: CudaAlloc>(
         &mut self,
         alloc: CombinedCudaAlloc<Self::CudaAllocation, A>,
-    ) -> rustacuda::error::CudaResult<A> {
+    ) -> cust::error::CudaResult<A> {
         self.inner.restore(alloc)
     }
 }
@@ -144,7 +144,7 @@ unsafe impl<T: StackOnly + PortableBitSemantics + TypeGraphLayout, const M2D: bo
         &self,
         alloc: A,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         Async<'_, 'stream, DeviceAccessible<Self::CudaRepresentation>>,
         CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
     )> {
@@ -156,7 +156,7 @@ unsafe impl<T: StackOnly + PortableBitSemantics + TypeGraphLayout, const M2D: bo
         this: owning_ref::BoxRefMut<'a, O, Self>,
         alloc: CombinedCudaAlloc<Self::CudaAllocationAsync, A>,
         stream: crate::host::Stream<'stream>,
-    ) -> rustacuda::error::CudaResult<(
+    ) -> cust::error::CudaResult<(
         Async<'a, 'stream, owning_ref::BoxRefMut<'a, O, Self>, CompletionFnMut<'a, Self>>,
         A,
     )> {

--- a/src/utils/exchange/wrapper.rs
+++ b/src/utils/exchange/wrapper.rs
@@ -251,10 +251,9 @@ impl<T: RustToCudaAsync<CudaAllocationAsync: EmptyCudaAlloc, CudaAllocation: Emp
 }
 
 impl<
-        'a,
         'stream,
         T: RustToCudaAsync<CudaAllocationAsync: EmptyCudaAlloc, CudaAllocation: EmptyCudaAlloc>,
-    > Async<'a, 'stream, ExchangeWrapperOnDevice<T>, NoCompletion>
+    > Async<'_, 'stream, ExchangeWrapperOnDevice<T>, NoCompletion>
 {
     /// Moves the data asynchronously back to the host CPU device.
     ///

--- a/src/utils/ffi.rs
+++ b/src/utils/ffi.rs
@@ -66,16 +66,16 @@ pub struct DeviceConstRef<'r, T: PortableBitSemantics + 'r> {
     pub(crate) reference: PhantomData<&'r T>,
 }
 
-impl<'r, T: PortableBitSemantics> Copy for DeviceConstRef<'r, T> {}
+impl<T: PortableBitSemantics> Copy for DeviceConstRef<'_, T> {}
 
-impl<'r, T: PortableBitSemantics> Clone for DeviceConstRef<'r, T> {
+impl<T: PortableBitSemantics> Clone for DeviceConstRef<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
 #[cfg(feature = "device")]
-impl<'r, T: PortableBitSemantics> AsRef<T> for DeviceConstRef<'r, T> {
+impl<T: PortableBitSemantics> AsRef<T> for DeviceConstRef<'_, T> {
     fn as_ref(&self) -> &T {
         unsafe { &*self.pointer.0 }
     }
@@ -90,14 +90,14 @@ pub struct DeviceMutRef<'r, T: PortableBitSemantics + 'r> {
 }
 
 #[cfg(feature = "device")]
-impl<'r, T: PortableBitSemantics> AsRef<T> for DeviceMutRef<'r, T> {
+impl<T: PortableBitSemantics> AsRef<T> for DeviceMutRef<'_, T> {
     fn as_ref(&self) -> &T {
         unsafe { &*self.pointer.0 }
     }
 }
 
 #[cfg(feature = "device")]
-impl<'r, T: PortableBitSemantics> AsMut<T> for DeviceMutRef<'r, T> {
+impl<T: PortableBitSemantics> AsMut<T> for DeviceMutRef<'_, T> {
     fn as_mut(&mut self) -> &mut T {
         unsafe { &mut *self.pointer.0 }
     }
@@ -113,14 +113,14 @@ pub struct DeviceOwnedRef<'r, T: PortableBitSemantics> {
 }
 
 #[cfg(feature = "device")]
-impl<'r, T: PortableBitSemantics> AsRef<T> for DeviceOwnedRef<'r, T> {
+impl<T: PortableBitSemantics> AsRef<T> for DeviceOwnedRef<'_, T> {
     fn as_ref(&self) -> &T {
         unsafe { &*self.pointer.0 }
     }
 }
 
 #[cfg(feature = "device")]
-impl<'r, T: PortableBitSemantics> AsMut<T> for DeviceOwnedRef<'r, T> {
+impl<T: PortableBitSemantics> AsMut<T> for DeviceOwnedRef<'_, T> {
     fn as_mut(&mut self) -> &mut T {
         unsafe { &mut *self.pointer.0 }
     }

--- a/src/utils/shared/slice.rs
+++ b/src/utils/shared/slice.rs
@@ -2,7 +2,6 @@ use core::alloc::Layout;
 
 use const_type_layout::TypeGraphLayout;
 
-#[expect(clippy::module_name_repetitions)]
 #[repr(transparent)]
 pub struct ThreadBlockSharedSlice<T: 'static + TypeGraphLayout> {
     shared: *mut [T],

--- a/src/utils/shared/slice.rs
+++ b/src/utils/shared/slice.rs
@@ -10,7 +10,7 @@ pub struct ThreadBlockSharedSlice<T: 'static + TypeGraphLayout> {
 impl<T: 'static + TypeGraphLayout> ThreadBlockSharedSlice<T> {
     #[cfg(feature = "host")]
     #[must_use]
-    pub fn new_uninit_with_len(len: usize) -> Self {
+    pub const fn new_uninit_with_len(len: usize) -> Self {
         Self {
             shared: Self::dangling_slice_with_len(len),
         }
@@ -18,7 +18,7 @@ impl<T: 'static + TypeGraphLayout> ThreadBlockSharedSlice<T> {
 
     #[cfg(feature = "host")]
     #[must_use]
-    pub fn with_len(mut self, len: usize) -> Self {
+    pub const fn with_len(mut self, len: usize) -> Self {
         self.shared = Self::dangling_slice_with_len(len);
         self
     }
@@ -31,7 +31,7 @@ impl<T: 'static + TypeGraphLayout> ThreadBlockSharedSlice<T> {
     }
 
     #[cfg(feature = "host")]
-    fn dangling_slice_with_len(len: usize) -> *mut [T] {
+    const fn dangling_slice_with_len(len: usize) -> *mut [T] {
         core::ptr::slice_from_raw_parts_mut(core::ptr::NonNull::dangling().as_ptr(), len)
     }
 


### PR DESCRIPTION
`rustacuda` is no longer maintained, and includes all of `rustacuda` and most of the custom patches we are using in `rust-cuda`.

However, the following incompatibilities remain:
- [ ] `cust_core::DeviceCopy` now has `Copy` as a supertrait. This is both too weak and too strong for `rust-cuda`. There is no workaround. If `cust` doesn't change this requirement, no migration can occur. https://github.com/Rust-GPU/Rust-CUDA/issues/124
  - postponed by forking `cust` to explore a better design
- [x] `Stream::wait_event` takes an owned `Event` and `Event`s cannot be cloned or inspected. This could be fixed by falling back to raw FFI for all usages. https://github.com/Rust-GPU/Rust-CUDA/issues/110
- [x] `Stream::add_callback` no longer provides access to the current stream status. The callback might just not be scheduled anymore if an error occurred (which could result in a never-resolving async future), or do something even worse. This could be fixed by falling back to raw FFI. https://stackoverflow.com/questions/56448390/how-to-recover-from-cuda-errors-when-using-cudalaunchhostfunc-instead-of-cudastr