### PR TITLE
Examine switching to cudarc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,12 @@ rust-cuda = { version = "0.1", path = ".", default-features = false }
 rust-cuda-derive = { version = "0.1", path = "rust-cuda-derive", default-features = false }
 rust-cuda-kernel = { version = "0.1", path = "rust-cuda-kernel", default-features = false }
 
-# third-party dependencies with unpublished patches
-rustacuda = { git = "https://github.com/juntyr/RustaCUDA", rev = "c6ea7cc", default-features = false }
-rustacuda_core = { git = "https://github.com/juntyr/RustaCUDA", rev = "c6ea7cc", default-features = false }
-
 # crates.io third-party dependencies
 cargo_metadata = { version = "0.19", default-features = false }
 cargo-util = { version = "=0.2.16", default-features = false }  # TODO: keep in sync with toolchain
 colored = { version = "3.0", default-features = false }
 const-type-layout = { version = "0.3.2", default-features = false }
+cudarc = { version = "0.13", default-features = false }
 final = { version = "0.1.1", default-features = false }
 find_cuda_helper = { version = "0.2", default-features = false }
 oneshot = { version = "0.1", default-features = false }
@@ -92,16 +89,15 @@ default = []
 derive = ["dep:rust-cuda-derive"]
 device = []
 final = ["dep:final"]
-host = ["dep:rustacuda", "dep:regex", "dep:oneshot", "dep:safer_owning_ref"]
+host = ["dep:cudarc", "dep:regex", "dep:oneshot", "dep:safer_owning_ref"]
 kernel = ["dep:rust-cuda-kernel"]
 
 [dependencies]
 const-type-layout = { workspace = true, features = ["derive"] }
+cudarc = { workspace = true, optional = true, features = ["cuda-version-from-build-system"] }
 final = { workspace = true, optional = true }
 oneshot = { workspace = true, features = ["std", "async"], optional = true }
 regex = { workspace = true, optional = true }
-rustacuda = { workspace = true, optional = true }
-rustacuda_core = { workspace = true }
 rust-cuda-derive = { workspace = true, optional = true }
 rust-cuda-kernel = { workspace = true, optional = true }
 safer_owning_ref = { workspace = true, optional = true }

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -7,6 +7,4 @@ pub extern crate const_type_layout;
 pub extern crate owning_ref;
 
 #[cfg(feature = "host")]
-pub extern crate rustacuda;
-
-pub extern crate rustacuda_core;
+pub extern crate cudarc;


### PR DESCRIPTION
Challenges encountered so far:

- cudarc only has the high-level DeviceSlice, no DeviceBox, though a simple wrapper around the result APIs could be written (since rust-cuda only needs it internally and doesn't expose it the memory unsafety)
- cudarc doesn't seem to have locked memory, if we would anyways switch to direct API calls this might be fine